### PR TITLE
Improvements - Groups and Projects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 	</parent>
 
 	<artifactId>connector-gitlab-rest</artifactId>
-	<version>1.2.0-SNAPSHOT</version>
+	<version>1.2.2-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>REST Connector Gitlab</name>

--- a/src/main/java/com/evolveum/polygon/connector/gitlab/rest/GitlabRestConfiguration.java
+++ b/src/main/java/com/evolveum/polygon/connector/gitlab/rest/GitlabRestConfiguration.java
@@ -32,9 +32,10 @@ public class GitlabRestConfiguration extends AbstractConfiguration implements St
 
 
 	private String loginUrl;
-        private String protocol;
+    private String protocol;
 	private GuardedString privateToken;
-        private String groupsToManage;
+    private String groupsToManage;
+    private String objectAvatar;
 	private static final Log LOGGER = Log.getLog(GitlabRestConnector.class);
         
 
@@ -62,25 +63,42 @@ public class GitlabRestConfiguration extends AbstractConfiguration implements St
 		this.loginUrl = loginURL;
 	}
         
-        // Add protocol configuration property to support https        
-        @ConfigurationProperty(order = 4, displayMessageKey = "protocol.display", helpMessageKey = "protocol.help", required = false, confidential = false)
+    // Add protocol configuration property to support https        
+    @ConfigurationProperty(order = 4, displayMessageKey = "protocol.display", helpMessageKey = "protocol.help", required = false, confidential = false)
 	public String getProtocol() {
-		return protocol;
+	    return protocol;
 	}
+       
+    // Add groupsToManage configuration property to limit number of groups and memberships in these groupd that will be managed by connector. If null or empty then all groups. Symbol Coma "," is delimiter       
+    @ConfigurationProperty(order = 5, displayMessageKey = "groupsToManage.display", helpMessageKey = "groupsToManage.help", required = false, confidential = false)
+
+    public String getGroupsToManage() {
+        return groupsToManage;
+    }
+
+    
+    // Add objectAvatar configuration property to support choose objectAvatar is selected or no by Groups and Project
+    // Workaroud for issue https://gitlab.com/gitlab-org/gitlab/-/issues/25498
+    //@ConfigurationProperty(order = 6, displayMessageKey = "objectAvatar.display", helpMessageKey = "objectAvatar.help", required = true, confidential = false)
+    
+    public String getObjectAvatar() {
+	    return objectAvatar;
+    }    
+    
+    public void setGroupsToManage(String groupsToManage) {
+         this.groupsToManage = groupsToManage;
+    }
+
+    public void setProtocol(String protocol) {
+         this.protocol = protocol;
+    }
+    
+    public void setObjectAvatar(String objectAvatar) {
+    	this.objectAvatar = objectAvatar;
+    }
+    
         
-        // Add groupsToManage configuration property to limit number of groups and memberships in these groupd that will be managed by connector. If null or empty then all groups. Symbol Coma "," is delimiter       
-        @ConfigurationProperty(order = 5, displayMessageKey = "groupsToManage.display", helpMessageKey = "groupsToManage.help", required = false, confidential = false)
-        public String getGroupsToManage() {
-            return groupsToManage;
-        }
-
-        public void setGroupsToManage(String groupsToManage) {
-            this.groupsToManage = groupsToManage;
-        }
-
-        public void setProtocol(String protocol) {
-            this.protocol = protocol;
-        }
+	    
 
 	@Override
 	public void validate() {
@@ -92,9 +110,13 @@ public class GitlabRestConfiguration extends AbstractConfiguration implements St
 			throw new ConfigurationException("Private Token cannot be empty.");
 		}
                 
-                if (protocol==null || !(protocol.equals("http") || protocol.equals("https") || protocol.isEmpty())) {
-			throw new ConfigurationException("Protocol should be http or https.");
+        if (protocol==null || !(protocol.equals("http") || protocol.equals("https") || protocol.isEmpty())) {
+		    throw new ConfigurationException("Protocol should be http or https.");
+        }
+		if (objectAvatar==null || !(objectAvatar.equals("true") || objectAvatar.equals("false") || objectAvatar.isEmpty())) {
+			throw new ConfigurationException("objectAvatar should be true or false.");
 		}
+		
 		LOGGER.info("Configuration valid");
 	}
 	

--- a/src/main/java/com/evolveum/polygon/connector/gitlab/rest/ObjectProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/gitlab/rest/ObjectProcessing.java
@@ -575,6 +575,11 @@ public class ObjectProcessing {
 
 	protected byte[] getAvatarPhoto(JSONObject object, String attrURLName, String attrName) {
 
+
+		if (this.configuration.getObjectAvatar().equals("false")) {
+			return null;
+		}
+		
 		if (object.has(attrURLName) && object.get(attrURLName) != null
 				&& !JSONObject.NULL.equals(object.get(attrURLName))) {
 

--- a/src/main/java/com/evolveum/polygon/connector/gitlab/rest/ProjectProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/gitlab/rest/ProjectProcessing.java
@@ -36,6 +36,7 @@ import org.identityconnectors.framework.common.objects.AttributeDelta;
 import org.identityconnectors.framework.common.objects.AttributeInfoBuilder;
 import org.identityconnectors.framework.common.objects.ConnectorObject;
 import org.identityconnectors.framework.common.objects.ConnectorObjectBuilder;
+import org.identityconnectors.framework.common.objects.Name;
 import org.identityconnectors.framework.common.objects.ObjectClass;
 import org.identityconnectors.framework.common.objects.ObjectClassInfoBuilder;
 import org.identityconnectors.framework.common.objects.OperationOptions;
@@ -388,6 +389,7 @@ public class ProjectProcessing extends GroupOrProjectProcessing {
 
 		// mandatory attributes
 		putRequestedAttrIfExists(create, attributes, "__NAME__", json, ATTR_NAME);
+		putRequestedAttrIfExists(create, attributes, Name.NAME, json, ATTR_PATH_WITH_NAMESPACE);
 
 		// optional attributes
 		putAttrIfExists(attributes, ATTR_PATH, String.class, json);
@@ -412,7 +414,9 @@ public class ProjectProcessing extends GroupOrProjectProcessing {
 		
 		LOGGER.info("Project request: {0}", json.toString());
 
-		return createPutOrPostRequest(uid, PROJECTS, json, create);
+		// Handling the case of Projects with fullpath
+		return createPutOrPostRequest(uid, PROJECTS, json, create, ATTR_PATH_WITH_NAMESPACE);
+		//return createPutOrPostRequest(uid, PROJECTS, json, create);
 	}
 	
 	protected void putTagListIfExists(Set<Attribute> attributes, JSONObject json) {
@@ -435,7 +439,8 @@ public class ProjectProcessing extends GroupOrProjectProcessing {
 		builder.setObjectClass(new ObjectClass(PROJECT_NAME));
 
 		getUIDIfExists(project, UID, builder);
-		getNAMEIfExists(project, ATTR_NAME, builder);
+		//getNAMEIfExists(project, ATTR_NAME, builder);
+		getNAMEIfExists(project, ATTR_PATH_WITH_NAMESPACE, builder);
 
 		getIfExists(project, ATTR_PATH, String.class, builder);
 		getIfExists(project, ATTR_DEFAULT_BRANCH, String.class, builder);

--- a/src/main/resources/com/evolveum/polygon/connector/gitlab/rest/Messages.properties
+++ b/src/main/resources/com/evolveum/polygon/connector/gitlab/rest/Messages.properties
@@ -13,3 +13,5 @@ protocol.display=Protocol
 protocol.help=Please provide the protocol of connection https or http(deffaut)
 groupsToManage.display=Group filter
 groupsToManage.help=List of groups to manage user membership in these groups (delimiter ","). Scope - Account ObjectClass. Empty value means all groups.
+objectAvatar.display=Object Avatar select
+objectAvatar.help=Choose between true or false for reading the avatar URL. If any group or project has an avatar, select false.


### PR DESCRIPTION
1. Implemented option to select or not to sync the avatar of projects and groups in Gitlab, to circumvent the open issue (https://gitlab.com/gitlab-org/gitlab/-/issues/25498)
2. Changed the synchronization/creation of Projects, to use the "path_with_namespace" instead of "name", because the previous field is not a unique id for the Project, as it is done with groups.