### PR TITLE
Performance improvements for user permissions mapping

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 	</parent>
 
 	<artifactId>connector-gitlab-rest</artifactId>
-	<version>1.2.2-SNAPSHOT</version>
+	<version>1.2.3-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>REST Connector Gitlab</name>

--- a/src/main/java/com/evolveum/polygon/connector/gitlab/rest/GitlabRestConnector.java
+++ b/src/main/java/com/evolveum/polygon/connector/gitlab/rest/GitlabRestConnector.java
@@ -21,10 +21,8 @@ package com.evolveum.polygon.connector.gitlab.rest;
  */
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -56,8 +54,8 @@ import org.identityconnectors.framework.spi.operations.UpdateDeltaOp;
 import org.identityconnectors.framework.spi.operations.DeleteOp;
 
 @ConnectorClass(displayNameKey = "connector.gitlab.rest.display", configurationClass = GitlabRestConfiguration.class)
-public class GitlabRestConnector implements TestOp, SchemaOp, Connector, CreateOp, DeleteOp, UpdateDeltaOp,
-		SearchOp<Filter> {
+public class GitlabRestConnector
+		implements TestOp, SchemaOp, Connector, CreateOp, DeleteOp, UpdateDeltaOp, SearchOp<Filter> {
 
 	private static final Log LOGGER = Log.getLog(GitlabRestConnector.class);
 	private GitlabRestConfiguration configuration;
@@ -65,7 +63,7 @@ public class GitlabRestConnector implements TestOp, SchemaOp, Connector, CreateO
 	private static final String USERS = "/users";
 	private static final String GROUPS = "/groups";
 	private static final String PROJECTS = "/projects";
-	
+
 	private static final String PROJECT_NAME = "Project";
 
 	private Schema schema = null;
@@ -76,10 +74,6 @@ public class GitlabRestConnector implements TestOp, SchemaOp, Connector, CreateO
 		ObjectProcessing objectProcessing = new ObjectProcessing(configuration, httpclient);
 		objectProcessing.test();
 	}
-	
-	
-	
-	
 
 	@Override
 	public void init(Configuration configuration) {
@@ -197,12 +191,12 @@ public class GitlabRestConnector implements TestOp, SchemaOp, Connector, CreateO
 			LOGGER.error("Attribute of type ResultsHandler not provided.");
 			throw new InvalidAttributeValueException("Attribute of type ResultsHandler is not provided.");
 		}
-		
+
 		if (options == null) {
 			LOGGER.error("Attribute of type OperationOptions not provided.");
 			throw new InvalidAttributeValueException("Attribute of type OperationOptions is not provided.");
 		}
-               
+
 		LOGGER.info("executeQuery on {0}, filter: {1}, options: {2}", objectClass, query, options);
 
 		if (objectClass.is(ObjectClass.ACCOUNT_NAME)) {
@@ -230,7 +224,7 @@ public class GitlabRestConnector implements TestOp, SchemaOp, Connector, CreateO
 	@Override
 	public Set<AttributeDelta> updateDelta(ObjectClass objectClass, Uid uid, Set<AttributeDelta> attrsDelta,
 			OperationOptions options) {
-		
+
 		if (objectClass == null) {
 			LOGGER.error("Parameter of type ObjectClass not provided.");
 			throw new InvalidAttributeValueException("Parameter of type ObjectClass not provided.");
@@ -245,58 +239,59 @@ public class GitlabRestConnector implements TestOp, SchemaOp, Connector, CreateO
 			LOGGER.error("Parameter of type Set<AttributeDelta> not provided.");
 			throw new InvalidAttributeValueException("Parameter of type Set<AttributeDelta> not provided.");
 		}
-		
+
 		if (options == null) {
 			LOGGER.error("Parameter of type OperationOptions not provided.");
 			throw new InvalidAttributeValueException("Parameter of type OperationOptions not provided.");
 		}
 
-		LOGGER.info("updateDelta on {0}, uid: {1}, attrDelta: {2}, options: {3}", objectClass, uid.getValue(), attrsDelta,options);
-		
+		LOGGER.info("updateDelta on {0}, uid: {1}, attrDelta: {2}, options: {3}", objectClass, uid.getValue(),
+				attrsDelta, options);
+
 		Set<Attribute> attributeReplace = new HashSet<Attribute>();
 		Set<AttributeDelta> attrsDeltaMultivalue = new HashSet<AttributeDelta>();
-		for (AttributeDelta attrDelta : attrsDelta){
+		for (AttributeDelta attrDelta : attrsDelta) {
 			List<Object> replaceValue = attrDelta.getValuesToReplace();
-			if(replaceValue != null){
+			if (replaceValue != null) {
 				attributeReplace.add(AttributeBuilder.build(attrDelta.getName(), replaceValue));
 			} else {
 				attrsDeltaMultivalue.add(attrDelta);
 			}
 		}
-		
+
 		if (objectClass.is(ObjectClass.ACCOUNT_NAME)) { // __ACCOUNT__
 			Set<AttributeDelta> ret = new HashSet<AttributeDelta>();
 			Uid newUid = null;
-			if(!attributeReplace.isEmpty()){
+			if (!attributeReplace.isEmpty()) {
 				UserProcessing userProcessing = new UserProcessing(configuration, httpclient);
 				newUid = userProcessing.createOrUpdateUser(uid, attributeReplace);
 			}
-			if(!attrsDeltaMultivalue.isEmpty()){
+			if (!attrsDeltaMultivalue.isEmpty()) {
 				UserProcessing userProcessing = new UserProcessing(configuration, httpclient);
 				userProcessing.updateDeltaMultiValues(uid, attrsDeltaMultivalue, options);
 			}
-			if(newUid == null ||newUid.equals(uid)){
+			if (newUid == null || newUid.equals(uid)) {
 				return ret;
 			} else {
-					
+
 				AttributeDelta newUidAttributeDelta = AttributeDeltaBuilder.build(Uid.NAME, newUid.getValue());
 				ret.add(newUidAttributeDelta);
 				return ret;
 			}
-			
+
 		} else if (objectClass.is(ObjectClass.GROUP_NAME)) { // __GROUP__
 			Set<AttributeDelta> ret = new HashSet<AttributeDelta>();
 			Uid newUid = null;
-			if(!attributeReplace.isEmpty()){
-			GroupProcessing groupProcessing = new GroupProcessing(configuration, httpclient);
-			newUid = groupProcessing.createOrUpdateGroup(uid, attributeReplace, options);
+			if (!attributeReplace.isEmpty()) {
+				GroupProcessing groupProcessing = new GroupProcessing(configuration, httpclient);
+				newUid = groupProcessing.createOrUpdateGroup(uid, attributeReplace, options);
 			}
-			if(!attrsDeltaMultivalue.isEmpty()){
+			if (!attrsDeltaMultivalue.isEmpty()) {
 				GroupProcessing groupProcessing = new GroupProcessing(configuration, httpclient);
 				groupProcessing.updateDeltaMultiValues(uid, attrsDeltaMultivalue, options);
 			}
-			if(newUid == null || newUid.equals(uid)){
-				return ret; 
+			if (newUid == null || newUid.equals(uid)) {
+				return ret;
 			} else {
 				AttributeDelta newUidAttributeDelta = AttributeDeltaBuilder.build(Uid.NAME, newUid.getValue());
 				ret.add(newUidAttributeDelta);
@@ -306,23 +301,22 @@ public class GitlabRestConnector implements TestOp, SchemaOp, Connector, CreateO
 		if (objectClass.is(PROJECT_NAME)) { // Project
 			Set<AttributeDelta> ret = new HashSet<AttributeDelta>();
 			Uid newUid = null;
-			if(!attributeReplace.isEmpty()){
-			ProjectProcessing projectProcessing = new ProjectProcessing(configuration, httpclient);
-			newUid = projectProcessing.createOrUpdateProject(uid, attributeReplace, options);
+			if (!attributeReplace.isEmpty()) {
+				ProjectProcessing projectProcessing = new ProjectProcessing(configuration, httpclient);
+				newUid = projectProcessing.createOrUpdateProject(uid, attributeReplace, options);
 			}
-			if(!attrsDeltaMultivalue.isEmpty()){
+			if (!attrsDeltaMultivalue.isEmpty()) {
 				ProjectProcessing projectProcessing = new ProjectProcessing(configuration, httpclient);
 				projectProcessing.updateDeltaMultiValues(uid, attrsDeltaMultivalue, options);
 			}
-			if(newUid == null || newUid.equals(uid)){
-				return ret; 
+			if (newUid == null || newUid.equals(uid)) {
+				return ret;
 			} else {
 				AttributeDelta newUidAttributeDelta = AttributeDeltaBuilder.build(Uid.NAME, newUid.getValue());
 				ret.add(newUidAttributeDelta);
 				return ret;
 			}
-		}
-		else {
+		} else {
 			LOGGER.error("The value of the ObjectClass parameter is unsupported.");
 			throw new UnsupportedOperationException("The value of the ObjectClass parameter is unsupported.");
 		}

--- a/src/main/java/com/evolveum/polygon/connector/gitlab/rest/GroupOrProjectProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/gitlab/rest/GroupOrProjectProcessing.java
@@ -64,13 +64,14 @@ public class GroupOrProjectProcessing extends ObjectProcessing {
 		super(configuration, httpclient);
 	}
 
-	//return map with access lever, that represent integer, and list of user's id (access lever "0" represent name of each members with their access level)
-	protected Map <Integer, List<String>> getMembers(URIBuilder uribuilderMember) {
-		
+	// return map with access lever, that represent integer, and list of user's id
+	// (access lever "0" represent name of each members with their access level)
+	protected Map<Integer, List<String>> getMembers(URIBuilder uribuilderMember) {
+		LOGGER.info("MAP getMembers Start");
 		JSONArray objectsMember = new JSONArray();
 		JSONArray partOfObjectsMember = new JSONArray();
 		int ii = 1;
-		do{
+		do {
 			URI uriMember;
 			try {
 				uribuilderMember.clearParameters();
@@ -80,48 +81,48 @@ public class GroupOrProjectProcessing extends ObjectProcessing {
 			} catch (URISyntaxException e) {
 				StringBuilder sb = new StringBuilder();
 				sb.append("It was not possible create URI from UriBuider:").append(uribuilderMember).append(";")
-					.append(e.getLocalizedMessage());
+						.append(e.getLocalizedMessage());
 				LOGGER.error(sb.toString());
 				throw new ConnectorException(sb.toString(), e);
 			}
-		
+
 			HttpRequestBase requestMember = new HttpGet(uriMember);
-		
+
 			partOfObjectsMember = callRequestForJSONArray(requestMember, true);
 			Iterator<Object> iterator = partOfObjectsMember.iterator();
-			while(iterator.hasNext()){
+			while (iterator.hasNext()) {
 				Object member = iterator.next();
 				objectsMember.put(member);
 			}
 			ii++;
-		} while(partOfObjectsMember.length() == 100);
-		
+		} while (partOfObjectsMember.length() == 100);
+
 		List<String> guestMembers = new ArrayList<>();
 		List<String> reporterMembers = new ArrayList<>();
 		List<String> developerMembers = new ArrayList<>();
 		List<String> masterMembers = new ArrayList<>();
 		List<String> ownerMembers = new ArrayList<>();
 		List<String> membersWithName = new ArrayList<>();
-		Map <Integer, List<String>> members = new HashMap<Integer, List<String>>();
+		Map<Integer, List<String>> members = new HashMap<Integer, List<String>>();
 		for (int i = 0; i < objectsMember.length(); i++) {
 			JSONObject jsonObjectMember = objectsMember.getJSONObject(i);
 			String userId = String.valueOf(jsonObjectMember.get(UID));
 			String userName = String.valueOf(jsonObjectMember.get(ATTR_USERNAME));
 			String expiresDate = String.valueOf(jsonObjectMember.get(ATTR_EXPIRES_AT));
-			int access_level = (int)jsonObjectMember.get(ATTR_ACCESS_LEVEL);
-			if(access_level == 10){
+			int access_level = (int) jsonObjectMember.get(ATTR_ACCESS_LEVEL);
+			if (access_level == 10) {
 				guestMembers.add(userId);
 			}
-			if(access_level == 20){
+			if (access_level == 20) {
 				reporterMembers.add(userId);
 			}
-			if(access_level == 30){
+			if (access_level == 30) {
 				developerMembers.add(userId);
 			}
-			if(access_level == 40){
+			if (access_level == 40) {
 				masterMembers.add(userId);
 			}
-			if(access_level == 50){
+			if (access_level == 50) {
 				ownerMembers.add(userId);
 			}
 			StringBuilder sb = new StringBuilder();
@@ -134,76 +135,78 @@ public class GroupOrProjectProcessing extends ObjectProcessing {
 		members.put(30, developerMembers);
 		members.put(40, masterMembers);
 		members.put(50, ownerMembers);
+		LOGGER.info("MAP getMembers End");
+		LOGGER.info("MAP getMembers -  members: {0}", members);
 		return members;
 	}
 
-	
-	protected URIBuilder createRequestForMembers(String path){
+	protected URIBuilder createRequestForMembers(String path) {
 		URIBuilder uribuilderMember = getURIBuilder();
 		StringBuilder sbPath = new StringBuilder();
 		sbPath.append(path).append(MEMBERS);
 		uribuilderMember.setPath(sbPath.toString());
 		return uribuilderMember;
 	}
-	
+
 	protected void addAttributeForMembers(ConnectorObjectBuilder builder, ResultsHandler handler, String path) {
 		URIBuilder uribuilderMember = createRequestForMembers(path);
-		Map <Integer, List<String>> members = getMembers(uribuilderMember);
-		
-		if(!members.get(10).isEmpty()){
+		Map<Integer, List<String>> members = getMembers(uribuilderMember);
+
+		if (!members.get(10).isEmpty()) {
 			builder.addAttribute(ATTR_GUEST_MEMBERS, members.get(10).toArray());
 		}
-		if(!members.get(20).isEmpty()){
+		if (!members.get(20).isEmpty()) {
 			builder.addAttribute(ATTR_REPORTER_MEMBERS, members.get(20).toArray());
 		}
-		if(!members.get(30).isEmpty()){
+		if (!members.get(30).isEmpty()) {
 			builder.addAttribute(ATTR_DEVELOPER_MEMBERS, members.get(30).toArray());
 		}
-		if(!members.get(40).isEmpty()){
+		if (!members.get(40).isEmpty()) {
 			builder.addAttribute(ATTR_MASTER_MEMBERS, members.get(40).toArray());
 		}
-		if(!members.get(50).isEmpty()){
+		if (!members.get(50).isEmpty()) {
 			builder.addAttribute(ATTR_OWNER_MEMBERS, members.get(50).toArray());
 		}
-		if(!members.get(0).isEmpty()){
+		if (!members.get(0).isEmpty()) {
 			builder.addAttribute(ATTR_MEMBERS_WITH_NAME, members.get(0).toArray());
 		}
 	}
 
-	public void updateDeltaMultiValuesForGroupOrProject(Uid uid, Set<AttributeDelta> attributesDelta, OperationOptions options,
-			String path) {
-		
-		LOGGER.info("updateDeltaMultiValuesForGroupOrProject on uid: {0}, attrDelta: {1}, options: {2}", uid.getValue(), attributesDelta, options);
-		
+	public void updateDeltaMultiValuesForGroupOrProject(Uid uid, Set<AttributeDelta> attributesDelta,
+			OperationOptions options, String path) {
+
+		LOGGER.info("updateDeltaMultiValuesForGroupOrProject on uid: {0}, attrDelta: {1}, options: {2}", uid.getValue(),
+				attributesDelta, options);
+
 		for (AttributeDelta attrDelta : attributesDelta) {
 
-			if (ATTR_GUEST_MEMBERS.equals(attrDelta.getName())) {  
+			if (ATTR_GUEST_MEMBERS.equals(attrDelta.getName())) {
 				createOrDeleteMember(uid, attrDelta, path, 10);
-				
+
 			}
-			if (ATTR_REPORTER_MEMBERS.equals(attrDelta.getName())) {  
+			if (ATTR_REPORTER_MEMBERS.equals(attrDelta.getName())) {
 				createOrDeleteMember(uid, attrDelta, path, 20);
-				
+
 			}
-			if (ATTR_DEVELOPER_MEMBERS.equals(attrDelta.getName())) {  
+			if (ATTR_DEVELOPER_MEMBERS.equals(attrDelta.getName())) {
 				createOrDeleteMember(uid, attrDelta, path, 30);
-				
+
 			}
-			if (ATTR_MASTER_MEMBERS.equals(attrDelta.getName())) {  
+			if (ATTR_MASTER_MEMBERS.equals(attrDelta.getName())) {
 				createOrDeleteMember(uid, attrDelta, path, 40);
-				
+
 			}
-			if (ATTR_OWNER_MEMBERS.equals(attrDelta.getName())) { 
+			if (ATTR_OWNER_MEMBERS.equals(attrDelta.getName())) {
 				createOrDeleteMember(uid, attrDelta, path, 50);
-				
+
 			}
 		}
 	}
-	private void createOrDeleteMember(Uid uid, AttributeDelta attrDelta,
-		String path, int accessLevel){
+
+	private void createOrDeleteMember(Uid uid, AttributeDelta attrDelta, String path, int accessLevel) {
 		StringBuilder sbPath = new StringBuilder();
 		sbPath.append(path).append("/").append(uid.getUidValue()).append(MEMBERS);
-		
+
 		List<Object> addValues = attrDelta.getValuesToAdd();
 		List<Object> removeValues = attrDelta.getValuesToRemove();
 		if (addValues != null && !addValues.isEmpty()) {

--- a/src/main/java/com/evolveum/polygon/connector/gitlab/rest/GroupProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/gitlab/rest/GroupProcessing.java
@@ -58,7 +58,7 @@ public class GroupProcessing extends GroupOrProjectProcessing {
 	private static final String ATTR_PARENT_ID = "parent_id";
 	private static final String ATTR_FULL_NAME = "full_name";
 	private static final String ATTR_FULL_PATH = "full_path";
-	
+
 	public GroupProcessing(GitlabRestConfiguration configuration, CloseableHttpClient httpclient) {
 		super(configuration, httpclient);
 	}
@@ -70,7 +70,8 @@ public class GroupProcessing extends GroupOrProjectProcessing {
 
 		// required
 		// ATTR_NAME and ATTR_PATH are required for creating groups
-		// However, we don't define ATTR_PATH as createable and updateable because we handle it from the value of ATTR_FULL_PATH which is
+		// However, we don't define ATTR_PATH as createable and updateable because we
+		// handle it from the value of ATTR_FULL_PATH which is
 		// defined as secondary identifier (__NAME__)
 		AttributeInfoBuilder attrNameBuilder = new AttributeInfoBuilder(ATTR_NAME);
 		attrNameBuilder.setRequired(true).setType(String.class).setCreateable(true).setUpdateable(true)
@@ -78,7 +79,7 @@ public class GroupProcessing extends GroupOrProjectProcessing {
 		groupObjClassBuilder.addAttributeInfo(attrNameBuilder.build());
 
 		// optional
-		//createable: FALSE && updateable: FALSE && readable: TRUE
+		// createable: FALSE && updateable: FALSE && readable: TRUE
 		AttributeInfoBuilder attrPathBuilder = new AttributeInfoBuilder(ATTR_PATH);
 		attrPathBuilder.setRequired(true).setType(String.class).setCreateable(false).setUpdateable(false)
 				.setReadable(true);
@@ -87,88 +88,98 @@ public class GroupProcessing extends GroupOrProjectProcessing {
 		AttributeInfoBuilder attrAvatarUrlBuilder = new AttributeInfoBuilder(ATTR_AVATAR_URL);
 		attrAvatarUrlBuilder.setType(String.class).setCreateable(false).setUpdateable(false).setReadable(true);
 		groupObjClassBuilder.addAttributeInfo(attrAvatarUrlBuilder.build());
-		
+
 		AttributeInfoBuilder attrFullNameBuilder = new AttributeInfoBuilder(ATTR_FULL_NAME);
 		attrFullNameBuilder.setType(String.class).setCreateable(false).setUpdateable(false).setReadable(true);
 		groupObjClassBuilder.addAttributeInfo(attrFullNameBuilder.build());
-		
+
 		AttributeInfoBuilder attrFullPathBuilder = new AttributeInfoBuilder(ATTR_FULL_PATH);
 		attrFullPathBuilder.setType(String.class).setCreateable(false).setUpdateable(false).setReadable(true);
 		groupObjClassBuilder.addAttributeInfo(attrFullPathBuilder.build());
-		
+
 		AttributeInfoBuilder avatarBuilder = new AttributeInfoBuilder(ATTR_AVATAR);
 		avatarBuilder.setType(byte[].class).setCreateable(false).setUpdateable(false).setReadable(true);
 		groupObjClassBuilder.addAttributeInfo(avatarBuilder.build());
-		
+
 		AttributeInfoBuilder attrRequestAccessEnabledBuilder = new AttributeInfoBuilder(ATTR_REQUEST_ACCESS_ENABLED);
-		attrRequestAccessEnabledBuilder.setType(Boolean.class).setCreateable(false).setUpdateable(false).setReadable(true);
+		attrRequestAccessEnabledBuilder.setType(Boolean.class).setCreateable(false).setUpdateable(false)
+				.setReadable(true);
 		groupObjClassBuilder.addAttributeInfo(attrRequestAccessEnabledBuilder.build());
-		
+
 		AttributeInfoBuilder attrWebUrlBuilder = new AttributeInfoBuilder(ATTR_WEB_URL);
 		attrWebUrlBuilder.setType(String.class).setCreateable(false).setUpdateable(false).setReadable(true);
 		groupObjClassBuilder.addAttributeInfo(attrWebUrlBuilder.build());
-		
-		//createable: TRUE && updateable: TRUE && readable: TRUE
+
+		// createable: TRUE && updateable: TRUE && readable: TRUE
 		AttributeInfoBuilder attrDescriptionBuilder = new AttributeInfoBuilder(ATTR_DESCRIPTION);
 		attrDescriptionBuilder.setType(String.class).setCreateable(true).setUpdateable(true).setReadable(true);
 		groupObjClassBuilder.addAttributeInfo(attrDescriptionBuilder.build());
-		
+
 		// attr visibility can be private, internal, or public
 		AttributeInfoBuilder attrVisibilityBuilder = new AttributeInfoBuilder(ATTR_VISIBILITY);
 		attrVisibilityBuilder.setType(String.class).setCreateable(true).setUpdateable(true).setReadable(true);
 		groupObjClassBuilder.addAttributeInfo(attrVisibilityBuilder.build());
-		
+
 		AttributeInfoBuilder attrLfsEnabledBuilder = new AttributeInfoBuilder(ATTR_LFS_ENABLED);
 		attrLfsEnabledBuilder.setType(Boolean.class).setCreateable(true).setUpdateable(true).setReadable(true);
 		groupObjClassBuilder.addAttributeInfo(attrLfsEnabledBuilder.build());
-		
-		//createable: TRUE && updateable: TRUE && readable: FALSE
+
+		// createable: TRUE && updateable: TRUE && readable: FALSE
 		AttributeInfoBuilder attrMembershipLockBuilder = new AttributeInfoBuilder(ATTR_MEMBERSHIP_LOCK);
-		attrMembershipLockBuilder.setType(Boolean.class).setCreateable(true).setUpdateable(true).setReadable(false).setReturnedByDefault(false);
+		attrMembershipLockBuilder.setType(Boolean.class).setCreateable(true).setUpdateable(true).setReadable(false)
+				.setReturnedByDefault(false);
 		groupObjClassBuilder.addAttributeInfo(attrMembershipLockBuilder.build());
-		
+
 		AttributeInfoBuilder attrShareWithGroupLockBuilder = new AttributeInfoBuilder(ATTR_SHARE_WITH_GROUP_LOCK);
 		attrShareWithGroupLockBuilder.setType(Boolean.class).setCreateable(true).setUpdateable(true).setReadable(true);
 		groupObjClassBuilder.addAttributeInfo(attrShareWithGroupLockBuilder.build());
-		
+
 		AttributeInfoBuilder attrParentIdBuilder = new AttributeInfoBuilder(ATTR_PARENT_ID);
 		attrParentIdBuilder.setType(Integer.class).setCreateable(true).setUpdateable(true).setReadable(true);
 		groupObjClassBuilder.addAttributeInfo(attrParentIdBuilder.build());
-		
-		//multivalued: TRUE && createable: FALSE && updateable: FALSE && readable: TRUE
+
+		// multivalued: TRUE && createable: FALSE && updateable: FALSE && readable: TRUE
 		AttributeInfoBuilder attrProjectsBuilder = new AttributeInfoBuilder(ATTR_PROJECTS);
-		attrProjectsBuilder.setType(String.class).setMultiValued(true).setCreateable(false).setUpdateable(false).setReadable(true);
+		attrProjectsBuilder.setType(String.class).setMultiValued(true).setCreateable(false).setUpdateable(false)
+				.setReadable(true);
 		groupObjClassBuilder.addAttributeInfo(attrProjectsBuilder.build());
-		
+
 		AttributeInfoBuilder attrSharedProjectsBuilder = new AttributeInfoBuilder(ATTR_SHARED_PROJECTS);
-		attrSharedProjectsBuilder.setType(String.class).setMultiValued(true).setCreateable(false).setUpdateable(false).setReadable(true);
+		attrSharedProjectsBuilder.setType(String.class).setMultiValued(true).setCreateable(false).setUpdateable(false)
+				.setReadable(true);
 		groupObjClassBuilder.addAttributeInfo(attrSharedProjectsBuilder.build());
-		
+
 		AttributeInfoBuilder attrMembersBuilder = new AttributeInfoBuilder(ATTR_MEMBERS_WITH_NAME);
-		attrMembersBuilder.setType(String.class).setMultiValued(true).setCreateable(false).setUpdateable(false).setReadable(true);
+		attrMembersBuilder.setType(String.class).setMultiValued(true).setCreateable(false).setUpdateable(false)
+				.setReadable(true);
 		groupObjClassBuilder.addAttributeInfo(attrMembersBuilder.build());
-		
-		//multivalued: TRUE && createable: TRUE && updateable: TRUE && readable: TRUE
+
+		// multivalued: TRUE && createable: TRUE && updateable: TRUE && readable: TRUE
 		AttributeInfoBuilder attrGuestMembersBuilder = new AttributeInfoBuilder(ATTR_GUEST_MEMBERS);
-		attrGuestMembersBuilder.setType(String.class).setMultiValued(true).setCreateable(true).setUpdateable(true).setReadable(true);
+		attrGuestMembersBuilder.setType(String.class).setMultiValued(true).setCreateable(true).setUpdateable(true)
+				.setReadable(true);
 		groupObjClassBuilder.addAttributeInfo(attrGuestMembersBuilder.build());
-		
+
 		AttributeInfoBuilder attrReporterMembersBuilder = new AttributeInfoBuilder(ATTR_REPORTER_MEMBERS);
-		attrReporterMembersBuilder.setType(String.class).setMultiValued(true).setCreateable(true).setUpdateable(true).setReadable(true);
+		attrReporterMembersBuilder.setType(String.class).setMultiValued(true).setCreateable(true).setUpdateable(true)
+				.setReadable(true);
 		groupObjClassBuilder.addAttributeInfo(attrReporterMembersBuilder.build());
-		
+
 		AttributeInfoBuilder attrDeveloperMembersBuilder = new AttributeInfoBuilder(ATTR_DEVELOPER_MEMBERS);
-		attrDeveloperMembersBuilder.setType(String.class).setMultiValued(true).setCreateable(true).setUpdateable(true).setReadable(true);
+		attrDeveloperMembersBuilder.setType(String.class).setMultiValued(true).setCreateable(true).setUpdateable(true)
+				.setReadable(true);
 		groupObjClassBuilder.addAttributeInfo(attrDeveloperMembersBuilder.build());
-		
+
 		AttributeInfoBuilder attrMasterMembersBuilder = new AttributeInfoBuilder(ATTR_MASTER_MEMBERS);
-		attrMasterMembersBuilder.setType(String.class).setMultiValued(true).setCreateable(true).setUpdateable(true).setReadable(true);
+		attrMasterMembersBuilder.setType(String.class).setMultiValued(true).setCreateable(true).setUpdateable(true)
+				.setReadable(true);
 		groupObjClassBuilder.addAttributeInfo(attrMasterMembersBuilder.build());
-		
+
 		AttributeInfoBuilder attrOwnerMembersBuilder = new AttributeInfoBuilder(ATTR_OWNER_MEMBERS);
-		attrOwnerMembersBuilder.setType(String.class).setMultiValued(true).setCreateable(true).setUpdateable(true).setReadable(true);
+		attrOwnerMembersBuilder.setType(String.class).setMultiValued(true).setCreateable(true).setUpdateable(true)
+				.setReadable(true);
 		groupObjClassBuilder.addAttributeInfo(attrOwnerMembersBuilder.build());
-		
+
 		schemaBuilder.defineObjectClass(groupObjClassBuilder.build());
 	}
 
@@ -207,7 +218,7 @@ public class GroupProcessing extends GroupOrProjectProcessing {
 
 				JSONObject parent = findGroupByFullPath(parentFullPath, operationOptions);
 				if (parent != null) {
-				    json.put(ATTR_PARENT_ID, parent.getInt(UID));
+					json.put(ATTR_PARENT_ID, parent.getInt(UID));
 				}
 			}
 		}
@@ -251,21 +262,16 @@ public class GroupProcessing extends GroupOrProjectProcessing {
 
 	public void executeQueryForGroup(Filter query, ResultsHandler handler, OperationOptions options) {
 		if (query instanceof EqualsFilter) {
-
 			if (((EqualsFilter) query).getAttribute() instanceof Uid) {
-
 				Uid uid = (Uid) ((EqualsFilter) query).getAttribute();
 				if (uid.getUidValue() == null) {
 					invalidAttributeValue("Uid", query);
 				}
 				StringBuilder sbPath = new StringBuilder();
 				sbPath.append(GROUPS).append("/").append(uid.getUidValue());
-				JSONObject group = (JSONObject) executeGetRequest(sbPath.toString(), null,
-						options, false);
+				JSONObject group = (JSONObject) executeGetRequest(sbPath.toString(), null, options, false);
 				processingObjectFromGET(group, handler, sbPath.toString());
-
-			}  else if (((EqualsFilter) query).getAttribute() instanceof Name) {
-
+			} else if (((EqualsFilter) query).getAttribute() instanceof Name) {
 				Name name = (Name) ((EqualsFilter) query).getAttribute();
 				if (name.getNameValue() == null) {
 					invalidAttributeValue("Name", query);
@@ -276,7 +282,6 @@ public class GroupProcessing extends GroupOrProjectProcessing {
 					sbPath.append(GROUPS).append("/").append(group.getInt(UID));
 					processingObjectFromGET(group, handler, sbPath.toString());
 				}
-
 			} else {
 				StringBuilder sb = new StringBuilder();
 				sb.append("Illegal search with attribute ").append(((EqualsFilter) query).getAttribute().getName())
@@ -284,9 +289,7 @@ public class GroupProcessing extends GroupOrProjectProcessing {
 				LOGGER.error(sb.toString());
 				throw new InvalidAttributeValueException(sb.toString());
 			}
-
 		} else if (query instanceof ContainsFilter) {
-
 			if (((ContainsFilter) query).getAttribute().getName().equals("__NAME__")
 					|| ((ContainsFilter) query).getAttribute().getName().equals(ATTR_PATH)) {
 
@@ -306,85 +309,86 @@ public class GroupProcessing extends GroupOrProjectProcessing {
 				throw new InvalidAttributeValueException(sb.toString());
 			}
 		} else if (query instanceof ContainsAllValuesFilter) {
-
-			if (((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_GUEST_MEMBERS) ||
-					((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_REPORTER_MEMBERS)||
-					((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_DEVELOPER_MEMBERS)||
-					((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_MASTER_MEMBERS)||
-					((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_OWNER_MEMBERS)) {
+			// Implemented the use of the "/memberships" route to optimize the query of the
+			// accesses of each user
+			if (((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_GUEST_MEMBERS)
+					|| ((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_REPORTER_MEMBERS)
+					|| ((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_DEVELOPER_MEMBERS)
+					|| ((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_MASTER_MEMBERS)
+					|| ((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_OWNER_MEMBERS)) {
 
 				List<Object> allValues = ((ContainsAllValuesFilter) query).getAttribute().getValue();
 				if (allValues == null) {
-					
+
 				}
-				
-				for(Object value:allValues){
-					if(value == null){
+
+				for (Object value : allValues) {
+					if (value == null) {
 						invalidAttributeValue(((ContainsAllValuesFilter) query).getAttribute().getName(), query);
 					}
 				}
-				
-				JSONArray groups = new JSONArray();
-				JSONArray partOfGroups = new JSONArray();
-				int ii = 1;
-				do{
-					Map<String, String> parameters = new HashMap<String, String>();
-					parameters.put(PAGE, String.valueOf(ii));
-					parameters.put(PER_PAGE, "100");
-					
-					partOfGroups = (JSONArray) executeGetRequest(GROUPS, parameters, null, true);
-					Iterator<Object> iterator = partOfGroups.iterator();
-					while(iterator.hasNext()){
-						Object group = iterator.next();
-						groups.put(group);
-					}
-					ii++;
-				} while(partOfGroups.length() == 100);
-				
+
+				String REGEX = "[\\[\\]]";
+				String uid = (((ContainsAllValuesFilter) query).getAttribute().getValue()).toString();
+
+				uid = uid.replaceAll(REGEX, "");
+
+				StringBuilder sbPath = new StringBuilder();
+				sbPath.append(USERS).append("/").append(uid).append("/").append(USERS_MEMBERSHIPS_URL);
+
+				String TYPE_MEMBERSHIPS_GROUP = "Namespace";
+				Map<Integer, Integer> groupByAccess = new HashMap<Integer, Integer>();
 				JSONArray groupsWithMPMembers = new JSONArray();
-				
-				JSONObject group;
-				for (int i = 0; i < groups.length(); i++) {
-					group = groups.getJSONObject(i);
-					Integer countOfSameMember = 0;
-					
-					StringBuilder sbPath = new StringBuilder();
-					sbPath.append(GROUPS).append("/").append(String.valueOf(group.get(UID)));
-					URIBuilder uribuilderMember = createRequestForMembers(sbPath.toString());
-					Map <Integer, List<String>> mapMembersGroup = getMembers(uribuilderMember);
-					List <String> membersGroup = null;
-					if(((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_GUEST_MEMBERS)){
+				Integer countOfSameMember = 0;
+
+				UserProcessing userProcessing = new UserProcessing(configuration, httpclient);
+				groupByAccess = userProcessing.getUserAccess(sbPath.toString(), TYPE_MEMBERSHIPS_GROUP);
+
+				Iterator<Integer> it = groupByAccess.keySet().iterator();
+
+				JSONObject group = new JSONObject();
+
+				while (it.hasNext()) {
+					Object groupID = it.next();
+
+					StringBuilder sbGroupPath = new StringBuilder();
+					sbGroupPath.append(GROUPS).append("/").append(groupID);
+
+					URIBuilder uribuilderMember = createRequestForMembers(sbGroupPath.toString());
+					Map<Integer, List<String>> mapMembersGroup = getMembers(uribuilderMember);
+
+					List<String> membersGroup = null;
+					if (((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_GUEST_MEMBERS)) {
 						membersGroup = mapMembersGroup.get(10);
 					}
-					if(((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_REPORTER_MEMBERS)){
+					if (((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_REPORTER_MEMBERS)) {
 						membersGroup = mapMembersGroup.get(20);
 					}
-					if(((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_DEVELOPER_MEMBERS)){
+					if (((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_DEVELOPER_MEMBERS)) {
 						membersGroup = mapMembersGroup.get(30);
 					}
-					if(((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_MASTER_MEMBERS)){
+					if (((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_MASTER_MEMBERS)) {
 						membersGroup = mapMembersGroup.get(40);
 					}
-					if(((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_OWNER_MEMBERS)){
+					if (((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_OWNER_MEMBERS)) {
 						membersGroup = mapMembersGroup.get(50);
 					}
-					if(membersGroup != null){
-						for(Object MPGroupMember : allValues){
-						
-							for(String groupMember : membersGroup){
-								if(groupMember.equals((String)MPGroupMember)){
+					if (membersGroup != null) {
+						for (Object MPGroupMember : allValues) {
+							for (String groupMember : membersGroup) {
+								if (groupMember.equals((String) MPGroupMember)) {
 									countOfSameMember++;
 									break;
 								}
 							}
 						}
-						if(countOfSameMember == allValues.size()){
+						if (countOfSameMember == allValues.size()) {
+							group = findGroupByID(groupID.toString(), options);
 							groupsWithMPMembers.put(group);
 						}
 					}
-					
 				}
-				
+				LOGGER.info("groupsWithMPMembers -  members: {0}", groupsWithMPMembers);
 				processingObjectFromGET(groupsWithMPMembers, handler);
 			} else {
 				StringBuilder sb = new StringBuilder();
@@ -418,13 +422,26 @@ public class GroupProcessing extends GroupOrProjectProcessing {
 		}
 		return null;
 	}
-	
+
+	private JSONObject findGroupByID(String groupID, OperationOptions options) {
+		Map<String, String> parameters = new HashMap<>();
+		parameters.put("with_custom_attributes", "no");
+		parameters.put("with_projects", "no");
+		StringBuilder sbPath = new StringBuilder();
+
+		sbPath.append(GROUPS).append("/").append(groupID);
+		JSONObject group = (JSONObject) executeGetRequest(sbPath.toString(), parameters, options, false);
+		if (group.getInt(UID) == Integer.parseInt(groupID)) {
+			return group;
+		}
+		return null;
+	}
+
 	private void processingObjectFromGET(JSONObject group, ResultsHandler handler, String sbPath) {
 		byte[] avaratPhoto = getAvatarPhoto(group, ATTR_AVATAR_URL, ATTR_AVATAR);
 		ConnectorObjectBuilder builder = convertGroupJSONObjectToConnectorObject(group, avaratPhoto);
 		addAttributeForMembers(builder, handler, sbPath);
 		ConnectorObject connectorObject = builder.build();
-		LOGGER.info("addAtributeMembers, connectorObject: {0}", connectorObject.toString());
 		handler.handle(connectorObject);
 	}
 
@@ -437,8 +454,9 @@ public class GroupProcessing extends GroupOrProjectProcessing {
 			processingObjectFromGET(group, handler, sbPath.toString());
 		}
 	}
-	
+
 	public void updateDeltaMultiValues(Uid uid, Set<AttributeDelta> attributes, OperationOptions options) {
 		updateDeltaMultiValuesForGroupOrProject(uid, attributes, options, GROUPS);
 	}
+
 }

--- a/src/main/java/com/evolveum/polygon/connector/gitlab/rest/ObjectProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/gitlab/rest/ObjectProcessing.java
@@ -75,6 +75,7 @@ public class ObjectProcessing {
 	private static final String HTTP_PROTOCOL = "http";
 
 	protected static final String USERS = "/users";
+	protected static final String USERS_MEMBERSHIPS_URL = "memberships";
 	protected static final String GROUPS = "/groups";
 	protected static final String PROJECTS = "/projects";
 	protected static final String MEMBERS = "/members";
@@ -90,9 +91,9 @@ public class ObjectProcessing {
 	protected static final String PAGE = "page";
 	protected static final String PER_PAGE = "per_page";
 	protected static final String PROJECT_NAME = "Project";
-        
-        protected static final String UPLOAD_URL = "/uploads/-/";
-        protected static final String PROTOCOL_APPENDER = "://";        
+
+	protected static final String UPLOAD_URL = "/uploads/-/";
+	protected static final String PROTOCOL_APPENDER = "://";
 
 	protected static final String ATTR_NAME = "name";
 	protected static final String ATTR_WEB_URL = "web_url";
@@ -105,8 +106,8 @@ public class ObjectProcessing {
 	private URIBuilder uriBuilder;
 	protected CloseableHttpClient httpclient;
 
-	private GitlabRestConfiguration configuration;
-	
+	protected GitlabRestConfiguration configuration;
+
 	public long firstStartTime;
 	public long firstEndTime;
 	public long secondStartTime;
@@ -116,18 +117,18 @@ public class ObjectProcessing {
 	public long firstDuration;
 	public long secondDuration;
 	public long thirdDuration;
-	
+
 	public ObjectProcessing(GitlabRestConfiguration configuration, CloseableHttpClient httpclient) {
 		this.configuration = configuration;
 		this.httpclient = httpclient;
 
 		StringBuilder sbHost = new StringBuilder();
 		sbHost.append(this.configuration.getLoginURL()).append(HOST_POSTFIX_API);
-                // Add https support
-                String protocol=HTTP_PROTOCOL;
-                if(this.configuration.getProtocol()!=null && !this.configuration.getProtocol().isEmpty()){
-                protocol=this.configuration.getProtocol();
-                }
+		// Add https support
+		String protocol = HTTP_PROTOCOL;
+		if (this.configuration.getProtocol() != null && !this.configuration.getProtocol().isEmpty()) {
+			protocol = this.configuration.getProtocol();
+		}
 		this.uriBuilder = new URIBuilder().setScheme(protocol).setHost(sbHost.toString());
 	}
 
@@ -365,10 +366,11 @@ public class ObjectProcessing {
 		}
 		return new Uid(stringId);
 	}
-	
+
 	protected void putAttrIfExists(Set<Attribute> attributes, String attrNameFromMP, Class<?> type, JSONObject json) {
 
-		LOGGER.info("PutAttrIfExists attributes: {0}, attrNameFromMP: {1}, type {2}, json: {3}", attributes.toString(), attrNameFromMP, type, json.toString());
+		LOGGER.info("PutAttrIfExists attributes: {0}, attrNameFromMP: {1}, type {2}, json: {3}", attributes.toString(),
+				attrNameFromMP, type, json.toString());
 
 		// put optional attribute
 
@@ -376,7 +378,7 @@ public class ObjectProcessing {
 			String valueAttr = getAttr(attributes, attrNameFromMP, String.class, null);
 			if (valueAttr != null) {
 				json.put(attrNameFromMP, valueAttr);
-			} 
+			}
 		} else if (type.equals(Integer.class)) {
 			Integer valueAttr = getAttr(attributes, attrNameFromMP, Integer.class, null);
 			if (valueAttr != null) {
@@ -389,13 +391,12 @@ public class ObjectProcessing {
 			}
 		}
 	}
-	
-	
 
 	protected void putAttrIfExists(Set<Attribute> attributes, String attrNameFromMP, Class<?> type, JSONObject json,
 			String attrNameToGitlab) {
 
-		LOGGER.info("PutAttrIfExists attributes: {0}, attrNameFromMP: {1}, type {2}, json: {3}, attrNameToGitlab: {4}", attributes.toString(), attrNameFromMP, type, json.toString(), attrNameToGitlab);
+		LOGGER.info("PutAttrIfExists attributes: {0}, attrNameFromMP: {1}, type {2}, json: {3}, attrNameToGitlab: {4}",
+				attributes.toString(), attrNameFromMP, type, json.toString(), attrNameToGitlab);
 
 		if (attrNameToGitlab == null) {
 			attrNameToGitlab = attrNameFromMP;
@@ -407,7 +408,7 @@ public class ObjectProcessing {
 			String valueAttr = getAttr(attributes, attrNameFromMP, String.class, null);
 			if (valueAttr != null) {
 				json.put(attrNameToGitlab, valueAttr);
-			} 
+			}
 		} else if (type.equals(Integer.class)) {
 			Integer valueAttr = getAttr(attributes, attrNameFromMP, Integer.class, null);
 			if (valueAttr != null) {
@@ -420,16 +421,18 @@ public class ObjectProcessing {
 			}
 		}
 	}
-	
+
 	protected void putRequestedAttrIfExists(Boolean create, Set<Attribute> attributes, String attrNameFromMP,
 			JSONObject json) {
 		putRequestedAttrIfExists(create, attributes, attrNameFromMP, json, null);
 	}
 
 	protected void putRequestedAttrIfExists(Boolean create, Set<Attribute> attributes, String attrNameFromMP,
-											JSONObject json, String attrNameToGitlab) {
+			JSONObject json, String attrNameToGitlab) {
 
-		LOGGER.info("putRequestedAttrIfExists create {0}, attributes: {1}, attrNameFromMP: {2} json: {3}, attrNameToGitlab: {4}", create.toString(), attributes.toString(), attrNameFromMP, json.toString(), attrNameToGitlab);
+		LOGGER.info(
+				"putRequestedAttrIfExists create {0}, attributes: {1}, attrNameFromMP: {2} json: {3}, attrNameToGitlab: {4}",
+				create.toString(), attributes.toString(), attrNameFromMP, json.toString(), attrNameToGitlab);
 
 		if (attrNameToGitlab == null) {
 			attrNameToGitlab = attrNameFromMP;
@@ -472,18 +475,20 @@ public class ObjectProcessing {
 		}
 	}
 
-	protected Object executeGetRequest(String path, Map<String, String> parameters, OperationOptions options, Boolean resultIsArray) {
-		LOGGER.info("executeGetRequest path {0}, parameters: {1}, options: {2}, result is array: {3}", path, parameters, options, resultIsArray);
+	protected Object executeGetRequest(String path, Map<String, String> parameters, OperationOptions options,
+			Boolean resultIsArray) {
+		LOGGER.info("executeGetRequest path {0}, parameters: {1}, options: {2}, result is array: {3}", path, parameters,
+				options, resultIsArray);
 		URIBuilder uribuilder = getURIBuilder();
 		uribuilder.clearParameters();
-                 int totalPages;		
+		int totalPages;
 		uribuilder.setPath(path);
 		if (options != null) {
 			Integer page = options.getPagedResultsOffset();
 			Integer perPage = options.getPageSize();
 			if (page != null) {
 				uribuilder.addParameter(PAGE, page.toString());
-			}                        
+			}
 			if (perPage != null) {
 				uribuilder.addParameter(PER_PAGE, perPage.toString());
 			}
@@ -496,40 +501,40 @@ public class ObjectProcessing {
 			}
 		}
 
-            try {
-                URI uri = uribuilder.build();
-                HttpRequestBase request = new HttpGet(uri);
-                //Get X-Total-Pages
-                HttpRequestBase totalPagesrequest = new HttpGet(uri);
-                totalPages = getTotalPages(totalPagesrequest);
+		try {
+			URI uri = uribuilder.build();
+			HttpRequestBase request = new HttpGet(uri);
+			// Get X-Total-Pages
+			HttpRequestBase totalPagesrequest = new HttpGet(uri);
+			totalPages = getTotalPages(totalPagesrequest);
 
-                if (resultIsArray) {
-                    if (totalPages == 1) {
-                        return callRequestForJSONArray(request, true);
-                    } else {
-                        JSONArray responce = new JSONArray();
-                        if (options == null || options.getPageSize() == null) {
-                            uribuilder.addParameter(PER_PAGE, "100");
-                        }
-                        for (int i = 0; i < totalPages; i++) {
-                            URI uriPaged = uribuilder.setParameter(PAGE, Integer.toString(i)).build();
-                            HttpRequestBase requestPaged = new HttpGet(uriPaged);
-                            JSONArray responcePaged = callRequestForJSONArray(requestPaged, true);
-                            responce = mergeJSONArrays(responce, responcePaged);
-                        }
-                        return responce;
+			if (resultIsArray) {
+				if (totalPages == 1) {
+					return callRequestForJSONArray(request, true);
+				} else {
+					JSONArray responce = new JSONArray();
+					if (options == null || options.getPageSize() == null) {
+						uribuilder.addParameter(PER_PAGE, "100");
+					}
+					for (int i = 0; i < totalPages; i++) {
+						URI uriPaged = uribuilder.setParameter(PAGE, Integer.toString(i)).build();
+						HttpRequestBase requestPaged = new HttpGet(uriPaged);
+						JSONArray responcePaged = callRequestForJSONArray(requestPaged, true);
+						responce = mergeJSONArrays(responce, responcePaged);
+					}
+					return responce;
 
-                    }
-                } else {
-                    return callRequest(request, true);
-                }
-            } catch (URISyntaxException e) {
-                StringBuilder sb = new StringBuilder();
-                sb.append("It was not possible create URI from UriBuider:").append(uriBuilder).append(";")
-                        .append(e.getLocalizedMessage());
-                throw new ConnectorException(sb.toString(), e);
-            }
-    }
+				}
+			} else {
+				return callRequest(request, true);
+			}
+		} catch (URISyntaxException e) {
+			StringBuilder sb = new StringBuilder();
+			sb.append("It was not possible create URI from UriBuider:").append(uriBuilder).append(";")
+					.append(e.getLocalizedMessage());
+			throw new ConnectorException(sb.toString(), e);
+		}
+	}
 
 	protected int getUIDIfExists(JSONObject object, String nameAttr, ConnectorObjectBuilder builder) {
 		if (object.has(nameAttr)) {
@@ -543,7 +548,7 @@ public class ObjectProcessing {
 			throw new InvalidAttributeValueException(sb.toString());
 		}
 	}
-	
+
 	protected int getUIDIfExists(JSONObject object, String nameAttr) {
 		if (object.has(nameAttr)) {
 			int uid = object.getInt(nameAttr);
@@ -575,28 +580,27 @@ public class ObjectProcessing {
 
 	protected byte[] getAvatarPhoto(JSONObject object, String attrURLName, String attrName) {
 
-
 		if (this.configuration.getObjectAvatar().equals("false")) {
 			return null;
 		}
-		
+
 		if (object.has(attrURLName) && object.get(attrURLName) != null
 				&& !JSONObject.NULL.equals(object.get(attrURLName))) {
 
 			HttpEntity responseEntity = null;
 			CloseableHttpResponse response = null;
 			try {
-                            
-                            String attrURLValue = "";
-                            if (String.valueOf(object.get(attrURLName)).startsWith(UPLOAD_URL)) {
-                                attrURLValue = this.configuration.getProtocol() + PROTOCOL_APPENDER + this.configuration.getLoginURL() + String.valueOf(object.get(attrURLName));
-                            } else {
-                                attrURLValue = String.valueOf(object.get(attrURLName));
-                            }
-                            URIBuilder uriPhoto = new URIBuilder(attrURLValue);
-                            URI uri = uriPhoto.build();
 
-                            
+				String attrURLValue = "";
+				if (String.valueOf(object.get(attrURLName)).startsWith(UPLOAD_URL)) {
+					attrURLValue = this.configuration.getProtocol() + PROTOCOL_APPENDER
+							+ this.configuration.getLoginURL() + String.valueOf(object.get(attrURLName));
+				} else {
+					attrURLValue = String.valueOf(object.get(attrURLName));
+				}
+				URIBuilder uriPhoto = new URIBuilder(attrURLValue);
+				URI uri = uriPhoto.build();
+
 				LOGGER.ok("uri: {0}", uri);
 				HttpRequestBase request = new HttpGet(uri);
 
@@ -618,35 +622,37 @@ public class ObjectProcessing {
 				// execute request
 				response = execute(request);
 				LOGGER.info("responsePhoto: {0}", response);
-				
+
 			} catch (URISyntaxException e) {
 				StringBuilder sb = new StringBuilder();
 				sb.append("It was not possible create URI from UriBuider; ").append(e.getLocalizedMessage());
 				throw new ConnectorException(sb.toString(), e);
 			}
-				
-				processResponseErrors(response);
-				responseEntity = response.getEntity();
-				
-			try{
-				
+
+			processResponseErrors(response);
+			responseEntity = response.getEntity();
+
+			try {
+
 				byte[] byteJPEG = EntityUtils.toByteArray(responseEntity);
 				responseClose(response);
 				return byteJPEG;
-				
+
 			} catch (IOException e) {
 				StringBuilder sb = new StringBuilder();
-				sb.append("It was not possible create byte[] from response entity: ").append(responseEntity).append("; ").append(e.getLocalizedMessage());
+				sb.append("It was not possible create byte[] from response entity: ").append(responseEntity)
+						.append("; ").append(e.getLocalizedMessage());
 				responseClose(response);
 				throw new ConnectorException(sb.toString(), e);
-			} 
+			}
 		}
 		return null;
 
 	}
 
 	protected void getIfExists(JSONObject object, String attrName, Class<?> type, ConnectorObjectBuilder builder) {
-		if (object.has(attrName) && object.get(attrName) != null && !JSONObject.NULL.equals(object.get(attrName)) && !String.valueOf(object.get(attrName)).isEmpty()) {
+		if (object.has(attrName) && object.get(attrName) != null && !JSONObject.NULL.equals(object.get(attrName))
+				&& !String.valueOf(object.get(attrName)).isEmpty()) {
 			if (type.equals(String.class)) {
 				addAttr(builder, attrName, String.valueOf(object.get(attrName)));
 			} else {
@@ -654,9 +660,11 @@ public class ObjectProcessing {
 			}
 		}
 	}
-	
-	protected void getIfExists(JSONObject object, String attrName, Class<?> type, ConnectorObjectBuilder builder, String MPName) {
-		if (object.has(attrName) && object.get(attrName) != null && !JSONObject.NULL.equals(object.get(attrName)) && !String.valueOf(object.get(attrName)).isEmpty()) {
+
+	protected void getIfExists(JSONObject object, String attrName, Class<?> type, ConnectorObjectBuilder builder,
+			String MPName) {
+		if (object.has(attrName) && object.get(attrName) != null && !JSONObject.NULL.equals(object.get(attrName))
+				&& !String.valueOf(object.get(attrName)).isEmpty()) {
 			if (type.equals(String.class)) {
 				addAttr(builder, MPName, String.valueOf(object.get(attrName)));
 			} else {
@@ -664,25 +672,31 @@ public class ObjectProcessing {
 			}
 		}
 	}
-	
-	protected void getIfExistsClampedJSON(JSONObject object, String attrName, String type, ConnectorObjectBuilder builder) {
+
+	protected void getIfExistsClampedJSON(JSONObject object, String attrName, String type,
+			ConnectorObjectBuilder builder) {
 		String fullName = attrName;
 		JSONObject processingObject = object;
-		while(fullName.contains(".")){
+		while (fullName.contains(".")) {
 			String partsName[] = fullName.split("[.]");
 			String basicAttrName = partsName[0];
-			if (processingObject.has(basicAttrName) && processingObject.get(basicAttrName) != null && !JSONObject.NULL.equals(processingObject.get(basicAttrName)) && !String.valueOf(processingObject.get(basicAttrName)).isEmpty()) {
+			if (processingObject.has(basicAttrName) && processingObject.get(basicAttrName) != null
+					&& !JSONObject.NULL.equals(processingObject.get(basicAttrName))
+					&& !String.valueOf(processingObject.get(basicAttrName)).isEmpty()) {
 				StringBuilder sb = new StringBuilder();
-				for(int i=1;i<partsName.length;i++){
+				for (int i = 1; i < partsName.length; i++) {
 					sb.append(partsName[i]);
-					if(i+1!=partsName.length){
-					sb.append(".");
+					if (i + 1 != partsName.length) {
+						sb.append(".");
 					}
 				}
 				String clampedAttrName = sb.toString();
 				JSONObject clampedObject = new JSONObject(String.valueOf(processingObject.get(basicAttrName)));
-				
-				if (!clampedAttrName.contains(".") && clampedObject.has(clampedAttrName) && clampedObject.get(clampedAttrName) != null && !JSONObject.NULL.equals(clampedObject.get(clampedAttrName)) && !String.valueOf(clampedObject.get(clampedAttrName)).isEmpty()) {
+
+				if (!clampedAttrName.contains(".") && clampedObject.has(clampedAttrName)
+						&& clampedObject.get(clampedAttrName) != null
+						&& !JSONObject.NULL.equals(clampedObject.get(clampedAttrName))
+						&& !String.valueOf(clampedObject.get(clampedAttrName)).isEmpty()) {
 					if (type.equals(String.class.toString())) {
 						addAttr(builder, attrName, String.valueOf(clampedObject.get(clampedAttrName)));
 					} else {
@@ -765,8 +779,8 @@ public class ObjectProcessing {
 
 	protected <T> T addAttr(ConnectorObjectBuilder builder, String attrName, T attrVal) {
 		if (attrVal != null) {
-			if(attrVal instanceof String){
-				String unescapeAttrVal = StringEscapeUtils.unescapeXml((String)attrVal);
+			if (attrVal instanceof String) {
+				String unescapeAttrVal = StringEscapeUtils.unescapeXml((String) attrVal);
 				builder.addAttribute(attrName, unescapeAttrVal);
 			} else {
 				builder.addAttribute(attrName, attrVal);
@@ -822,7 +836,7 @@ public class ObjectProcessing {
 		} else if (statusCode == 409) {
 			responseClose(response);
 			throw new AlreadyExistsException(message);
-		} 
+		}
 		// other codes
 		responseClose(response);
 		throw new ConnectorException(message);
@@ -838,45 +852,45 @@ public class ObjectProcessing {
 		}
 	}
 
-    private int getTotalPages(HttpRequestBase request) {
-        LOGGER.info("request X-Total-Pages: {0}", request.getURI());
-        int totalPages;
+	private int getTotalPages(HttpRequestBase request) {
+		LOGGER.info("request X-Total-Pages: {0}", request.getURI());
+		int totalPages;
 
-        final StringBuilder privateToken = new StringBuilder();
-        if (this.configuration.getPrivateToken() != null) {
-            Accessor accessor = new GuardedString.Accessor() {
-                @Override
-                public void access(char[] chars) {
-                    privateToken.append(new String(chars));
-                }
-            };
-            this.configuration.getPrivateToken().access(accessor);
-        }
-        request.addHeader("PRIVATE-TOKEN", privateToken.toString());
-        request.addHeader("Content-Type", "application/json; charset=utf-8");
+		final StringBuilder privateToken = new StringBuilder();
+		if (this.configuration.getPrivateToken() != null) {
+			Accessor accessor = new GuardedString.Accessor() {
+				@Override
+				public void access(char[] chars) {
+					privateToken.append(new String(chars));
+				}
+			};
+			this.configuration.getPrivateToken().access(accessor);
+		}
+		request.addHeader("PRIVATE-TOKEN", privateToken.toString());
+		request.addHeader("Content-Type", "application/json; charset=utf-8");
 
-        // execute request
-        CloseableHttpResponse response = execute(request);
-        Header responseHeaderTotalPage = response.getFirstHeader("X-Total-Pages");        
-        if (responseHeaderTotalPage != null) {
-            totalPages = Integer.parseInt(responseHeaderTotalPage.getValue());
-        } else {
-            totalPages = 1;
-        }
-        LOGGER.info("X-Total-Pages: {0}", totalPages);
-        responseClose(response);
-        return totalPages;
-    }
+		// execute request
+		CloseableHttpResponse response = execute(request);
+		Header responseHeaderTotalPage = response.getFirstHeader("X-Total-Pages");
+		if (responseHeaderTotalPage != null) {
+			totalPages = Integer.parseInt(responseHeaderTotalPage.getValue());
+		} else {
+			totalPages = 1;
+		}
+		LOGGER.info("X-Total-Pages: {0}", totalPages);
+		responseClose(response);
+		return totalPages;
+	}
 
-    private JSONArray mergeJSONArrays(JSONArray rootArr, JSONArray addArr) {
+	private JSONArray mergeJSONArrays(JSONArray rootArr, JSONArray addArr) {
 
-        JSONArray sourceArray = new JSONArray(rootArr.toString());
-        JSONArray destinationArray = new JSONArray(addArr.toString());
+		JSONArray sourceArray = new JSONArray(rootArr.toString());
+		JSONArray destinationArray = new JSONArray(addArr.toString());
 
-        for (int i = 0; i < sourceArray.length(); i++) {
-            destinationArray.put(sourceArray.getJSONObject(i));
-        }
-        return destinationArray;
-    }
+		for (int i = 0; i < sourceArray.length(); i++) {
+			destinationArray.put(sourceArray.getJSONObject(i));
+		}
+		return destinationArray;
+	}
 
 }

--- a/src/main/java/com/evolveum/polygon/connector/gitlab/rest/ProjectProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/gitlab/rest/ProjectProcessing.java
@@ -95,7 +95,7 @@ public class ProjectProcessing extends GroupOrProjectProcessing {
 	private static final String ATTR_OWNER_STATE = "owner.state";
 	private static final String ATTR_OWNER_AVATAR_URL = "owner.avatar_url";
 	private static final String ATTR_OWNER_WEB_URL = "owner.web_url";
-	
+
 	private static final String ATTR_SHARED_WITH_GROUPS_ID_MAX_GUEST = "shared_with_groups_max_guest";
 	private static final String ATTR_SHARED_WITH_GROUPS_ID_MAX_REPORTER = "shared_with_groups_reporter";
 	private static final String ATTR_SHARED_WITH_GROUPS_ID_MAX_DEVELOPER = "shared_with_groups_max_developer";
@@ -117,264 +117,300 @@ public class ProjectProcessing extends GroupOrProjectProcessing {
 		projectObjClassBuilder.setType(PROJECT_NAME);
 
 		// optional
-		//createable: TRUE && updateable: TRUE && readable: TRUE
+		// createable: TRUE && updateable: TRUE && readable: TRUE
 		AttributeInfoBuilder attrPathBuilder = new AttributeInfoBuilder(ATTR_PATH);
 		attrPathBuilder.setType(String.class).setCreateable(true).setUpdateable(true).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrPathBuilder.build());
-		
+
 		AttributeInfoBuilder attrDescriptionBuilder = new AttributeInfoBuilder(ATTR_DESCRIPTION);
 		attrDescriptionBuilder.setType(String.class).setCreateable(true).setUpdateable(true).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrDescriptionBuilder.build());
-		
+
 		AttributeInfoBuilder attrDefaultBranchBuilder = new AttributeInfoBuilder(ATTR_DEFAULT_BRANCH);
-		attrDefaultBranchBuilder.setType(String.class).setCreateable(false).setUpdateable(true).setReadable(true).setReturnedByDefault(true);
+		attrDefaultBranchBuilder.setType(String.class).setCreateable(false).setUpdateable(true).setReadable(true)
+				.setReturnedByDefault(true);
 		projectObjClassBuilder.addAttributeInfo(attrDefaultBranchBuilder.build());
-		
+
 		// attr visibility can be private, internal, or public
 		AttributeInfoBuilder attrVisibilityLevelBuilder = new AttributeInfoBuilder(ATTR_VISIBILITY);
 		attrVisibilityLevelBuilder.setType(String.class).setCreateable(true).setUpdateable(true).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrVisibilityLevelBuilder.build());
-		
+
 		AttributeInfoBuilder attrLfsEnabledBuilder = new AttributeInfoBuilder(ATTR_LFS_ENABLED);
 		attrLfsEnabledBuilder.setType(Boolean.class).setCreateable(true).setUpdateable(true).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrLfsEnabledBuilder.build());
-		
+
 		AttributeInfoBuilder attrRequestAccessEnabledBuilder = new AttributeInfoBuilder(ATTR_REQUEST_ACCESS_ENABLED);
-		attrRequestAccessEnabledBuilder.setType(Boolean.class).setCreateable(true).setUpdateable(true).setReadable(true);
+		attrRequestAccessEnabledBuilder.setType(Boolean.class).setCreateable(true).setUpdateable(true)
+				.setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrRequestAccessEnabledBuilder.build());
-		
+
 		AttributeInfoBuilder attrPublicBuilder = new AttributeInfoBuilder(ATTR_PUBLIC_JOBS);
 		attrPublicBuilder.setType(Boolean.class).setCreateable(true).setUpdateable(true).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrPublicBuilder.build());
-		
-		AttributeInfoBuilder attrContainerRegistryEnabledBuilder = new AttributeInfoBuilder(ATTR_CONTAINER_REGISTRY_ENABLED);
-		attrContainerRegistryEnabledBuilder.setType(Boolean.class).setCreateable(true).setUpdateable(true).setReadable(true);
+
+		AttributeInfoBuilder attrContainerRegistryEnabledBuilder = new AttributeInfoBuilder(
+				ATTR_CONTAINER_REGISTRY_ENABLED);
+		attrContainerRegistryEnabledBuilder.setType(Boolean.class).setCreateable(true).setUpdateable(true)
+				.setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrContainerRegistryEnabledBuilder.build());
-		
+
 		AttributeInfoBuilder attrIssuesEnabledBuilder = new AttributeInfoBuilder(ATTR_ISSUES_ENABLED);
 		attrIssuesEnabledBuilder.setType(Boolean.class).setCreateable(true).setUpdateable(true).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrIssuesEnabledBuilder.build());
-		
+
 		AttributeInfoBuilder attrMergeRequestsEnabledBuilder = new AttributeInfoBuilder(ATTR_MERGE_REQUESTS_ENABLED);
-		attrMergeRequestsEnabledBuilder.setType(Boolean.class).setCreateable(true).setUpdateable(true).setReadable(true);
+		attrMergeRequestsEnabledBuilder.setType(Boolean.class).setCreateable(true).setUpdateable(true)
+				.setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrMergeRequestsEnabledBuilder.build());
-		
+
 		AttributeInfoBuilder attrWikiEnabledBuilder = new AttributeInfoBuilder(ATTR_WIKI_ENABLED);
 		attrWikiEnabledBuilder.setType(Boolean.class).setCreateable(true).setUpdateable(true).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrWikiEnabledBuilder.build());
-		
+
 //		AttributeInfoBuilder attrBuildsEnabledBuilder = new AttributeInfoBuilder(ATTR_BUILDS_ENABLED);
 //		attrBuildsEnabledBuilder.setType(Boolean.class).setCreateable(true).setUpdateable(true).setReadable(true);
 //		projectObjClassBuilder.addAttributeInfo(attrBuildsEnabledBuilder.build());
-		
+
 		AttributeInfoBuilder attrSnippetsEnabledBuilder = new AttributeInfoBuilder(ATTR_SNIPPETS_ENABLED);
 		attrSnippetsEnabledBuilder.setType(Boolean.class).setCreateable(true).setUpdateable(true).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrSnippetsEnabledBuilder.build());
-		
+
 		AttributeInfoBuilder attrSharedRunnersEnabledBuilder = new AttributeInfoBuilder(ATTR_SHARED_RUNNERS_ENABLED);
-		attrSharedRunnersEnabledBuilder.setType(Boolean.class).setCreateable(true).setUpdateable(true).setReadable(true);
+		attrSharedRunnersEnabledBuilder.setType(Boolean.class).setCreateable(true).setUpdateable(true)
+				.setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrSharedRunnersEnabledBuilder.build());
-		
+
 		AttributeInfoBuilder attrJobsEnabledBuilder = new AttributeInfoBuilder(ATTR_JOBS_ENABLED);
 		attrJobsEnabledBuilder.setType(Boolean.class).setCreateable(true).setUpdateable(true).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrJobsEnabledBuilder.build());
-		
+
 //		AttributeInfoBuilder attrOnlyAllowMergeIfBuildSucceeedsBuilder = new AttributeInfoBuilder(ATTR_ONLY_ALLOW_MERGE_IF_BUILD_SUCCEEDS);
 //		attrOnlyAllowMergeIfBuildSucceeedsBuilder.setType(Boolean.class).setCreateable(true).setUpdateable(true).setReadable(true);
 //		projectObjClassBuilder.addAttributeInfo(attrOnlyAllowMergeIfBuildSucceeedsBuilder.build());
-		
-		AttributeInfoBuilder attrOnlyAllowMergeIfPipelineSucceeedsBuilder = new AttributeInfoBuilder(ATTR_ONLY_ALLOW_MERGE_IF_PIPELINE_SUCCEEDS);
-		attrOnlyAllowMergeIfPipelineSucceeedsBuilder.setType(Boolean.class).setCreateable(true).setUpdateable(true).setReadable(true);
+
+		AttributeInfoBuilder attrOnlyAllowMergeIfPipelineSucceeedsBuilder = new AttributeInfoBuilder(
+				ATTR_ONLY_ALLOW_MERGE_IF_PIPELINE_SUCCEEDS);
+		attrOnlyAllowMergeIfPipelineSucceeedsBuilder.setType(Boolean.class).setCreateable(true).setUpdateable(true)
+				.setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrOnlyAllowMergeIfPipelineSucceeedsBuilder.build());
-		
-		AttributeInfoBuilder attrOnlyAllowMergeIfAllDiscussionsAreResolvedBuilder = new AttributeInfoBuilder(ATTR_ONLY_ALLOW_MERGE_IF_ALL_DISCUSSIONS_ARE_RESOLVED);
-		attrOnlyAllowMergeIfAllDiscussionsAreResolvedBuilder.setType(Boolean.class).setCreateable(true).setUpdateable(true).setReadable(true);
+
+		AttributeInfoBuilder attrOnlyAllowMergeIfAllDiscussionsAreResolvedBuilder = new AttributeInfoBuilder(
+				ATTR_ONLY_ALLOW_MERGE_IF_ALL_DISCUSSIONS_ARE_RESOLVED);
+		attrOnlyAllowMergeIfAllDiscussionsAreResolvedBuilder.setType(Boolean.class).setCreateable(true)
+				.setUpdateable(true).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrOnlyAllowMergeIfAllDiscussionsAreResolvedBuilder.build());
-		
+
 //		//createable: TRUE && updateable: TRUE && readable: FALSE
 //		AttributeInfoBuilder attrPublicBuildsBuilder = new AttributeInfoBuilder(ATTR_PUBLIC_BUILDS);
 //		attrPublicBuildsBuilder.setType(Boolean.class).setCreateable(true).setUpdateable(true).setReadable(false);
 //		projectObjClassBuilder.addAttributeInfo(attrPublicBuildsBuilder.build());
-		
-		//createable: FALSE && updateable: FALSE && readable: TRUE
+
+		// createable: FALSE && updateable: FALSE && readable: TRUE
 		AttributeInfoBuilder attrNameWithNamespaceBuilder = new AttributeInfoBuilder(ATTR_NAME_WITH_NAMESPACE);
 		attrNameWithNamespaceBuilder.setType(String.class).setCreateable(false).setUpdateable(false).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrNameWithNamespaceBuilder.build());
-		
+
 		AttributeInfoBuilder attrPathWithNamespaceBuilder = new AttributeInfoBuilder(ATTR_PATH_WITH_NAMESPACE);
 		attrPathWithNamespaceBuilder.setType(String.class).setCreateable(false).setUpdateable(false).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrPathWithNamespaceBuilder.build());
-		
+
 		AttributeInfoBuilder attrWebUrlBuilder = new AttributeInfoBuilder(ATTR_WEB_URL);
 		attrWebUrlBuilder.setType(String.class).setCreateable(false).setUpdateable(false).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrWebUrlBuilder.build());
-		
+
 		AttributeInfoBuilder attrArchivedBuilder = new AttributeInfoBuilder(ATTR_ARCHIVED);
 		attrArchivedBuilder.setType(Boolean.class).setCreateable(false).setUpdateable(false).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrArchivedBuilder.build());
-		
+
 		AttributeInfoBuilder attrSSHUrlToRepoBuilder = new AttributeInfoBuilder(ATTR_SSH_URL_TO_REPO);
 		attrSSHUrlToRepoBuilder.setType(String.class).setCreateable(false).setUpdateable(false).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrSSHUrlToRepoBuilder.build());
-		
+
 		AttributeInfoBuilder attrHTTPUrlToRepoBuilder = new AttributeInfoBuilder(ATTR_HTTP_URL_TO_REPO);
 		attrHTTPUrlToRepoBuilder.setType(String.class).setCreateable(false).setUpdateable(false).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrHTTPUrlToRepoBuilder.build());
-		
+
 		AttributeInfoBuilder attrCreateAtBuilder = new AttributeInfoBuilder(ATTR_CREATED_AT);
 		attrCreateAtBuilder.setType(String.class).setCreateable(false).setUpdateable(false).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrCreateAtBuilder.build());
-		
+
 		AttributeInfoBuilder attrLastActivityAtBuilder = new AttributeInfoBuilder(ATTR_LAST_ACTIVITY_AT);
 		attrLastActivityAtBuilder.setType(String.class).setCreateable(false).setUpdateable(false).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrLastActivityAtBuilder.build());
-		
+
 		AttributeInfoBuilder attrCreatorIDBuilder = new AttributeInfoBuilder(ATTR_CREATOR_ID);
 		attrCreatorIDBuilder.setType(Integer.class).setCreateable(false).setUpdateable(false).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrCreatorIDBuilder.build());
-		
+
 		AttributeInfoBuilder attrNameSpaceIdBuilder = new AttributeInfoBuilder(ATTR_NAMESPACE_ID);
 		attrNameSpaceIdBuilder.setType(String.class).setCreateable(false).setUpdateable(false).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrNameSpaceIdBuilder.build());
-		
+
 		AttributeInfoBuilder attrNameSpaceNameBuilder = new AttributeInfoBuilder(ATTR_NAMESPACE_NAME);
 		attrNameSpaceNameBuilder.setType(String.class).setCreateable(false).setUpdateable(false).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrNameSpaceNameBuilder.build());
-		
+
 		AttributeInfoBuilder attrNameSpacePathBuilder = new AttributeInfoBuilder(ATTR_NAMESPACE_PATH);
 		attrNameSpacePathBuilder.setType(String.class).setCreateable(false).setUpdateable(false).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrNameSpacePathBuilder.build());
-		
+
 		AttributeInfoBuilder attrNameSpaceKindBuilder = new AttributeInfoBuilder(ATTR_NAMESPACE_KIND);
 		attrNameSpaceKindBuilder.setType(String.class).setCreateable(false).setUpdateable(false).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrNameSpaceKindBuilder.build());
-		
+
 		AttributeInfoBuilder attrNameSpaceFullPathBuilder = new AttributeInfoBuilder(ATTR_NAMESPACE_FULL_PATH);
 		attrNameSpaceFullPathBuilder.setType(String.class).setCreateable(false).setUpdateable(false).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrNameSpaceFullPathBuilder.build());
-		
+
 		AttributeInfoBuilder attrStarCountBuilder = new AttributeInfoBuilder(ATTR_STAR_COUNT);
 		attrStarCountBuilder.setType(Integer.class).setCreateable(false).setUpdateable(false).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrStarCountBuilder.build());
-		
+
 		AttributeInfoBuilder attrForksCountBuilder = new AttributeInfoBuilder(ATTR_FORKS_COUNT);
 		attrForksCountBuilder.setType(Integer.class).setCreateable(false).setUpdateable(false).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrForksCountBuilder.build());
-		
+
 		AttributeInfoBuilder attrOpenIssuesCountBuilder = new AttributeInfoBuilder(ATTR_OPEN_ISSUES_COUNT);
 		attrOpenIssuesCountBuilder.setType(Integer.class).setCreateable(false).setUpdateable(false).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrOpenIssuesCountBuilder.build());
-		
-		AttributeInfoBuilder attrPermissionsGroupAccessLevelBuilder = new AttributeInfoBuilder(ATTR_PERMISSIONS_GROUP_ACCESS_LEVEL);
-		attrPermissionsGroupAccessLevelBuilder.setType(Integer.class).setCreateable(false).setUpdateable(false).setReadable(true);
+
+		AttributeInfoBuilder attrPermissionsGroupAccessLevelBuilder = new AttributeInfoBuilder(
+				ATTR_PERMISSIONS_GROUP_ACCESS_LEVEL);
+		attrPermissionsGroupAccessLevelBuilder.setType(Integer.class).setCreateable(false).setUpdateable(false)
+				.setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrPermissionsGroupAccessLevelBuilder.build());
-		
-		AttributeInfoBuilder attrPermissionsGroupNotificationLevelBuilder = new AttributeInfoBuilder(ATTR_PERMISSIONS_GROUP_ACCESS_NOTIFICATION_LEVEL);
-		attrPermissionsGroupNotificationLevelBuilder.setType(Integer.class).setCreateable(false).setUpdateable(false).setReadable(true);
+
+		AttributeInfoBuilder attrPermissionsGroupNotificationLevelBuilder = new AttributeInfoBuilder(
+				ATTR_PERMISSIONS_GROUP_ACCESS_NOTIFICATION_LEVEL);
+		attrPermissionsGroupNotificationLevelBuilder.setType(Integer.class).setCreateable(false).setUpdateable(false)
+				.setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrPermissionsGroupNotificationLevelBuilder.build());
-		
-		AttributeInfoBuilder attrPermissionsProjectAccessLevelBuilder = new AttributeInfoBuilder(ATTR_PERMISSIONS_PROJECT_ACCESS_LEVEL);
-		attrPermissionsProjectAccessLevelBuilder.setType(Integer.class).setCreateable(false).setUpdateable(false).setReadable(true);
+
+		AttributeInfoBuilder attrPermissionsProjectAccessLevelBuilder = new AttributeInfoBuilder(
+				ATTR_PERMISSIONS_PROJECT_ACCESS_LEVEL);
+		attrPermissionsProjectAccessLevelBuilder.setType(Integer.class).setCreateable(false).setUpdateable(false)
+				.setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrPermissionsProjectAccessLevelBuilder.build());
-		
-		AttributeInfoBuilder attrPermissionsProjectNotificationLevelBuilder = new AttributeInfoBuilder(ATTR_PERMISSIONS_PROJECT_ACCESS_NOTIFICATION_LEVEL);
-		attrPermissionsProjectNotificationLevelBuilder.setType(Integer.class).setCreateable(false).setUpdateable(false).setReadable(true);
+
+		AttributeInfoBuilder attrPermissionsProjectNotificationLevelBuilder = new AttributeInfoBuilder(
+				ATTR_PERMISSIONS_PROJECT_ACCESS_NOTIFICATION_LEVEL);
+		attrPermissionsProjectNotificationLevelBuilder.setType(Integer.class).setCreateable(false).setUpdateable(false)
+				.setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrPermissionsProjectNotificationLevelBuilder.build());
-		
+
 		AttributeInfoBuilder attrOwnerNameBuilder = new AttributeInfoBuilder(ATTR_OWNER_NAME);
 		attrOwnerNameBuilder.setType(String.class).setCreateable(false).setUpdateable(false).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrOwnerNameBuilder.build());
-		
+
 		AttributeInfoBuilder attrOwnerUsernameBuilder = new AttributeInfoBuilder(ATTR_OWNER_USERNAME);
 		attrOwnerUsernameBuilder.setType(String.class).setCreateable(false).setUpdateable(false).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrOwnerUsernameBuilder.build());
-		
+
 		AttributeInfoBuilder attrOwnerIdBuilder = new AttributeInfoBuilder(ATTR_OWNER_ID);
 		attrOwnerIdBuilder.setType(String.class).setCreateable(false).setUpdateable(false).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrOwnerIdBuilder.build());
-		
+
 		AttributeInfoBuilder attrOwnerStateBuilder = new AttributeInfoBuilder(ATTR_OWNER_STATE);
 		attrOwnerStateBuilder.setType(String.class).setCreateable(false).setUpdateable(false).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrOwnerStateBuilder.build());
-		
+
 		AttributeInfoBuilder attrOwnerAvatarUrlBuilder = new AttributeInfoBuilder(ATTR_OWNER_AVATAR_URL);
 		attrOwnerAvatarUrlBuilder.setType(String.class).setCreateable(false).setUpdateable(false).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrOwnerAvatarUrlBuilder.build());
-		
+
 		AttributeInfoBuilder attrOwnerWebUrlBuilder = new AttributeInfoBuilder(ATTR_OWNER_WEB_URL);
 		attrOwnerWebUrlBuilder.setType(String.class).setCreateable(false).setUpdateable(false).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrOwnerWebUrlBuilder.build());
-		
+
 		AttributeInfoBuilder attrAvatarUrlBuilder = new AttributeInfoBuilder(ATTR_AVATAR_URL);
 		attrAvatarUrlBuilder.setType(String.class).setCreateable(false).setUpdateable(false).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrAvatarUrlBuilder.build());
-		
+
 		AttributeInfoBuilder attrRunnersTokenBuilder = new AttributeInfoBuilder(ATTR_RUNNERS_TOKEN);
 		attrRunnersTokenBuilder.setType(String.class).setCreateable(false).setUpdateable(false).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrRunnersTokenBuilder.build());
-		
+
 		AttributeInfoBuilder attrImportStatusBuilder = new AttributeInfoBuilder(ATTR_IMPORT_STATUS);
 		attrImportStatusBuilder.setType(String.class).setCreateable(false).setUpdateable(false).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrImportStatusBuilder.build());
-		
+
 		AttributeInfoBuilder attrImportErrorBuilder = new AttributeInfoBuilder(ATTR_IMPORT_ERROR);
 		attrImportErrorBuilder.setType(String.class).setCreateable(false).setUpdateable(false).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrImportErrorBuilder.build());
-		
+
 		AttributeInfoBuilder avatarBuilder = new AttributeInfoBuilder(ATTR_AVATAR);
-		avatarBuilder.setType(byte[].class).setCreateable(false).setUpdateable(false).setReadable(true).setReturnedByDefault(true);
+		avatarBuilder.setType(byte[].class).setCreateable(false).setUpdateable(false).setReadable(true)
+				.setReturnedByDefault(true);
 		projectObjClassBuilder.addAttributeInfo(avatarBuilder.build());
-		
-		//multivalued: TRUE && createable: FALSE && updateable: FALSE && readable: TRUE
+
+		// multivalued: TRUE && createable: FALSE && updateable: FALSE && readable: TRUE
 		AttributeInfoBuilder attrSharedWithGroupsBuilder = new AttributeInfoBuilder(ATTR_SHARED_WITH_GROUPS);
-		attrSharedWithGroupsBuilder.setType(String.class).setMultiValued(true).setCreateable(false).setUpdateable(false).setReadable(true);
+		attrSharedWithGroupsBuilder.setType(String.class).setMultiValued(true).setCreateable(false).setUpdateable(false)
+				.setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrSharedWithGroupsBuilder.build());
-		
+
 		AttributeInfoBuilder attrMembersBuilder = new AttributeInfoBuilder(ATTR_MEMBERS_WITH_NAME);
-		attrMembersBuilder.setType(String.class).setMultiValued(true).setCreateable(false).setUpdateable(false).setReadable(true);
+		attrMembersBuilder.setType(String.class).setMultiValued(true).setCreateable(false).setUpdateable(false)
+				.setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrMembersBuilder.build());
-		
-		AttributeInfoBuilder attrSharedWithGroupsWithNameBuilder = new AttributeInfoBuilder(ATTR_SHARED_WITH_GROUPS_WITH_NAME);
-		attrSharedWithGroupsWithNameBuilder.setType(String.class).setMultiValued(true).setCreateable(false).setUpdateable(false).setReadable(true);
+
+		AttributeInfoBuilder attrSharedWithGroupsWithNameBuilder = new AttributeInfoBuilder(
+				ATTR_SHARED_WITH_GROUPS_WITH_NAME);
+		attrSharedWithGroupsWithNameBuilder.setType(String.class).setMultiValued(true).setCreateable(false)
+				.setUpdateable(false).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrSharedWithGroupsWithNameBuilder.build());
-		
-		//multivalued: TRUE && createable: TRUE && updateable: TRUE && readable:TRUE
+
+		// multivalued: TRUE && createable: TRUE && updateable: TRUE && readable:TRUE
 		AttributeInfoBuilder attrTagListBuilder = new AttributeInfoBuilder(ATTR_TAG_LIST);
-		attrTagListBuilder.setType(String.class).setMultiValued(true).setCreateable(true).setUpdateable(true).setReadable(true).setReturnedByDefault(true);
+		attrTagListBuilder.setType(String.class).setMultiValued(true).setCreateable(true).setUpdateable(true)
+				.setReadable(true).setReturnedByDefault(true);
 		projectObjClassBuilder.addAttributeInfo(attrTagListBuilder.build());
-		
+
 		AttributeInfoBuilder attrGuestMembersBuilder = new AttributeInfoBuilder(ATTR_GUEST_MEMBERS);
-		attrGuestMembersBuilder.setType(String.class).setMultiValued(true).setCreateable(true).setUpdateable(true).setReadable(true);
+		attrGuestMembersBuilder.setType(String.class).setMultiValued(true).setCreateable(true).setUpdateable(true)
+				.setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrGuestMembersBuilder.build());
-		
+
 		AttributeInfoBuilder attrReporterMembersBuilder = new AttributeInfoBuilder(ATTR_REPORTER_MEMBERS);
-		attrReporterMembersBuilder.setType(String.class).setMultiValued(true).setCreateable(true).setUpdateable(true).setReadable(true);
+		attrReporterMembersBuilder.setType(String.class).setMultiValued(true).setCreateable(true).setUpdateable(true)
+				.setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrReporterMembersBuilder.build());
-		
+
 		AttributeInfoBuilder attrDeveloperMembersBuilder = new AttributeInfoBuilder(ATTR_DEVELOPER_MEMBERS);
-		attrDeveloperMembersBuilder.setType(String.class).setMultiValued(true).setCreateable(true).setUpdateable(true).setReadable(true);
+		attrDeveloperMembersBuilder.setType(String.class).setMultiValued(true).setCreateable(true).setUpdateable(true)
+				.setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrDeveloperMembersBuilder.build());
-		
+
 		AttributeInfoBuilder attrMasterMembersBuilder = new AttributeInfoBuilder(ATTR_MASTER_MEMBERS);
-		attrMasterMembersBuilder.setType(String.class).setMultiValued(true).setCreateable(true).setUpdateable(true).setReadable(true);
+		attrMasterMembersBuilder.setType(String.class).setMultiValued(true).setCreateable(true).setUpdateable(true)
+				.setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrMasterMembersBuilder.build());
-		
-		AttributeInfoBuilder attrSharedWithGroupsMaxGuestBuilder = new AttributeInfoBuilder(ATTR_SHARED_WITH_GROUPS_ID_MAX_GUEST);
-		attrSharedWithGroupsMaxGuestBuilder.setType(String.class).setMultiValued(true).setCreateable(true).setUpdateable(true).setReadable(true);
+
+		AttributeInfoBuilder attrSharedWithGroupsMaxGuestBuilder = new AttributeInfoBuilder(
+				ATTR_SHARED_WITH_GROUPS_ID_MAX_GUEST);
+		attrSharedWithGroupsMaxGuestBuilder.setType(String.class).setMultiValued(true).setCreateable(true)
+				.setUpdateable(true).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrSharedWithGroupsMaxGuestBuilder.build());
-		
-		AttributeInfoBuilder attrSharedWithGroupsMaxReporterBuilder = new AttributeInfoBuilder(ATTR_SHARED_WITH_GROUPS_ID_MAX_REPORTER);
-		attrSharedWithGroupsMaxReporterBuilder.setType(String.class).setMultiValued(true).setCreateable(true).setUpdateable(true).setReadable(true);
+
+		AttributeInfoBuilder attrSharedWithGroupsMaxReporterBuilder = new AttributeInfoBuilder(
+				ATTR_SHARED_WITH_GROUPS_ID_MAX_REPORTER);
+		attrSharedWithGroupsMaxReporterBuilder.setType(String.class).setMultiValued(true).setCreateable(true)
+				.setUpdateable(true).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrSharedWithGroupsMaxReporterBuilder.build());
-		
-		AttributeInfoBuilder attrSharedWithGroupsMaxDeveloperBuilder = new AttributeInfoBuilder(ATTR_SHARED_WITH_GROUPS_ID_MAX_DEVELOPER);
-		attrSharedWithGroupsMaxDeveloperBuilder.setType(String.class).setMultiValued(true).setCreateable(true).setUpdateable(true).setReadable(true);
+
+		AttributeInfoBuilder attrSharedWithGroupsMaxDeveloperBuilder = new AttributeInfoBuilder(
+				ATTR_SHARED_WITH_GROUPS_ID_MAX_DEVELOPER);
+		attrSharedWithGroupsMaxDeveloperBuilder.setType(String.class).setMultiValued(true).setCreateable(true)
+				.setUpdateable(true).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrSharedWithGroupsMaxDeveloperBuilder.build());
-		
-		AttributeInfoBuilder attrSharedWithGroupsMaxMasterBuilder = new AttributeInfoBuilder(ATTR_SHARED_WITH_GROUPS_ID_MAX_MASTER);
-		attrSharedWithGroupsMaxMasterBuilder.setType(String.class).setMultiValued(true).setCreateable(true).setUpdateable(true).setReadable(true);
+
+		AttributeInfoBuilder attrSharedWithGroupsMaxMasterBuilder = new AttributeInfoBuilder(
+				ATTR_SHARED_WITH_GROUPS_ID_MAX_MASTER);
+		attrSharedWithGroupsMaxMasterBuilder.setType(String.class).setMultiValued(true).setCreateable(true)
+				.setUpdateable(true).setReadable(true);
 		projectObjClassBuilder.addAttributeInfo(attrSharedWithGroupsMaxMasterBuilder.build());
-				
+
 		schemaBuilder.defineObjectClass(projectObjClassBuilder.build());
 	}
 
@@ -406,19 +442,19 @@ public class ProjectProcessing extends GroupOrProjectProcessing {
 		putAttrIfExists(attributes, ATTR_VISIBILITY, String.class, json);
 		putAttrIfExists(attributes, ATTR_JOBS_ENABLED, Boolean.class, json);
 		putAttrIfExists(attributes, ATTR_REQUEST_ACCESS_ENABLED, Boolean.class, json);
-		putAttrIfExists(attributes, ATTR_ONLY_ALLOW_MERGE_IF_ALL_DISCUSSIONS_ARE_RESOLVED, Boolean.class,json);
+		putAttrIfExists(attributes, ATTR_ONLY_ALLOW_MERGE_IF_ALL_DISCUSSIONS_ARE_RESOLVED, Boolean.class, json);
 		putAttrIfExists(attributes, ATTR_ONLY_ALLOW_MERGE_IF_PIPELINE_SUCCEEDS, Boolean.class, json);
 		putAttrIfExists(attributes, ATTR_DEFAULT_BRANCH, String.class, json);
-		
+
 		putTagListIfExists(attributes, json);
-		
+
 		LOGGER.info("Project request: {0}", json.toString());
 
 		// Handling the case of Projects with fullpath
 		return createPutOrPostRequest(uid, PROJECTS, json, create, ATTR_PATH_WITH_NAMESPACE);
-		//return createPutOrPostRequest(uid, PROJECTS, json, create);
+		// return createPutOrPostRequest(uid, PROJECTS, json, create);
 	}
-	
+
 	protected void putTagListIfExists(Set<Attribute> attributes, JSONObject json) {
 
 		LOGGER.info("PutTagListIfExists attributes: {0}, json: {1}", attributes.toString(), json.toString());
@@ -429,7 +465,7 @@ public class ProjectProcessing extends GroupOrProjectProcessing {
 				if (vals != null && !vals.isEmpty()) {
 					json.put(ATTR_TAG_LIST, vals);
 				}
-				
+
 			}
 		}
 	}
@@ -439,7 +475,7 @@ public class ProjectProcessing extends GroupOrProjectProcessing {
 		builder.setObjectClass(new ObjectClass(PROJECT_NAME));
 
 		getUIDIfExists(project, UID, builder);
-		//getNAMEIfExists(project, ATTR_NAME, builder);
+		// getNAMEIfExists(project, ATTR_NAME, builder);
 		getNAMEIfExists(project, ATTR_PATH_WITH_NAMESPACE, builder);
 
 		getIfExists(project, ATTR_PATH, String.class, builder);
@@ -469,16 +505,18 @@ public class ProjectProcessing extends GroupOrProjectProcessing {
 		getIfExists(project, ATTR_JOBS_ENABLED, Integer.class, builder);
 		getIfExists(project, ATTR_ONLY_ALLOW_MERGE_IF_ALL_DISCUSSIONS_ARE_RESOLVED, Boolean.class, builder);
 		getIfExists(project, ATTR_ONLY_ALLOW_MERGE_IF_PIPELINE_SUCCEEDS, Boolean.class, builder);
-		
+
 		getIfExistsClampedJSON(project, ATTR_NAMESPACE_ID, Integer.class.toString(), builder);
 		getIfExistsClampedJSON(project, ATTR_NAMESPACE_NAME, String.class.toString(), builder);
 		getIfExistsClampedJSON(project, ATTR_NAMESPACE_PATH, String.class.toString(), builder);
 		getIfExistsClampedJSON(project, ATTR_NAMESPACE_KIND, String.class.toString(), builder);
 		getIfExistsClampedJSON(project, ATTR_NAMESPACE_FULL_PATH, String.class.toString(), builder);
 		getIfExistsClampedJSON(project, ATTR_PERMISSIONS_GROUP_ACCESS_LEVEL, Integer.class.toString(), builder);
-		getIfExistsClampedJSON(project, ATTR_PERMISSIONS_GROUP_ACCESS_NOTIFICATION_LEVEL, Integer.class.toString(), builder);
+		getIfExistsClampedJSON(project, ATTR_PERMISSIONS_GROUP_ACCESS_NOTIFICATION_LEVEL, Integer.class.toString(),
+				builder);
 		getIfExistsClampedJSON(project, ATTR_PERMISSIONS_PROJECT_ACCESS_LEVEL, Integer.class.toString(), builder);
-		getIfExistsClampedJSON(project, ATTR_PERMISSIONS_PROJECT_ACCESS_NOTIFICATION_LEVEL, Integer.class.toString(), builder);
+		getIfExistsClampedJSON(project, ATTR_PERMISSIONS_PROJECT_ACCESS_NOTIFICATION_LEVEL, Integer.class.toString(),
+				builder);
 		getIfExistsClampedJSON(project, ATTR_OWNER_NAME, Integer.class.toString(), builder);
 		getIfExistsClampedJSON(project, ATTR_OWNER_USERNAME, Integer.class.toString(), builder);
 		getIfExistsClampedJSON(project, ATTR_OWNER_ID, Integer.class.toString(), builder);
@@ -490,11 +528,10 @@ public class ProjectProcessing extends GroupOrProjectProcessing {
 		getMultiIfExists(project, ATTR_SHARED_WITH_GROUPS, builder);
 
 		addAttr(builder, ATTR_AVATAR, avatarPhoto);
-		
 
 		return builder;
 	}
-	
+
 	public void executeQueryForProject(Filter query, ResultsHandler handler, OperationOptions options) {
 		if (query instanceof EqualsFilter) {
 
@@ -506,8 +543,7 @@ public class ProjectProcessing extends GroupOrProjectProcessing {
 				}
 				StringBuilder sbPath = new StringBuilder();
 				sbPath.append(PROJECTS).append("/").append(uid.getUidValue());
-				JSONObject project = (JSONObject) executeGetRequest(sbPath.toString(), null,
-						options, false);
+				JSONObject project = (JSONObject) executeGetRequest(sbPath.toString(), null, options, false);
 				processingObjectFromGET(project, handler, sbPath.toString());
 
 			} else if (((EqualsFilter) query).getAttribute().getName().equals(ATTR_VISIBILITY)) {
@@ -516,9 +552,8 @@ public class ProjectProcessing extends GroupOrProjectProcessing {
 					invalidAttributeValue(ATTR_VISIBILITY, query);
 				}
 				Map<String, String> parameters = new HashMap<String, String>();
-				parameters.put(ATTR_VISIBILITY, (String)allValues.get(0));
-				JSONArray projects = (JSONArray) executeGetRequest(PROJECTS, parameters, options,
-						true);
+				parameters.put(ATTR_VISIBILITY, (String) allValues.get(0));
+				JSONArray projects = (JSONArray) executeGetRequest(PROJECTS, parameters, options, true);
 				processingObjectFromGET(projects, handler);
 			} else {
 				StringBuilder sb = new StringBuilder();
@@ -540,8 +575,7 @@ public class ProjectProcessing extends GroupOrProjectProcessing {
 				}
 				Map<String, String> parameters = new HashMap<String, String>();
 				parameters.put(SEARCH, allValues.get(0).toString());
-				JSONArray projects = (JSONArray) executeGetRequest(PROJECTS, parameters, options,
-						true);
+				JSONArray projects = (JSONArray) executeGetRequest(PROJECTS, parameters, options, true);
 				processingObjectFromGET(projects, handler);
 
 			} else {
@@ -552,11 +586,10 @@ public class ProjectProcessing extends GroupOrProjectProcessing {
 				throw new InvalidAttributeValueException(sb.toString());
 			}
 		} else if (query instanceof ContainsAllValuesFilter) {
-
-			if (((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_GUEST_MEMBERS) ||
-					((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_REPORTER_MEMBERS)||
-					((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_DEVELOPER_MEMBERS)||
-					((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_MASTER_MEMBERS)) {
+			if (((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_GUEST_MEMBERS)
+					|| ((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_REPORTER_MEMBERS)
+					|| ((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_DEVELOPER_MEMBERS)
+					|| ((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_MASTER_MEMBERS)) {
 
 				List<Object> allValues = ((ContainsAllValuesFilter) query).getAttribute().getValue();
 				if (allValues == null) {
@@ -566,76 +599,85 @@ public class ProjectProcessing extends GroupOrProjectProcessing {
 					LOGGER.error(sb.toString());
 					throw new InvalidAttributeValueException(sb.toString());
 				}
-				
-				for(Object value:allValues){
-					if(value == null){
+
+				for (Object value : allValues) {
+					if (value == null) {
 						invalidAttributeValue(((ContainsAllValuesFilter) query).getAttribute().getName(), query);
 					}
 				}
-				
-				JSONArray projects = new JSONArray();
-				JSONArray partOfProjects = new JSONArray();
-				int ii = 1;
-				do{
-					Map<String, String> parameters = new HashMap<String, String>();
-					parameters.put(PAGE, String.valueOf(ii));
-					parameters.put(PER_PAGE, "100");
-					
-					partOfProjects = (JSONArray) executeGetRequest(PROJECTS, parameters, null, true);
-					Iterator<Object> iterator = partOfProjects.iterator();
-					while(iterator.hasNext()){
-						Object project = iterator.next();
-						projects.put(project);
-					}
-					ii++;
-				} while(partOfProjects.length() == 100);
-				
-				JSONArray projectsWithMPMembers = new JSONArray();
-				
-				JSONObject project;
-				for (int i = 0; i < projects.length(); i++) {
-					project = projects.getJSONObject(i);
-					Integer countOfSameMember = 0;
-					
-					StringBuilder sbPath = new StringBuilder();
-					sbPath.append(PROJECTS).append("/").append(String.valueOf(project.get(UID)));
-					URIBuilder uribuilderMember = createRequestForMembers(sbPath.toString());
-					Map <Integer, List<String>> mapMembersProjects = getMembers(uribuilderMember);
-					List <String> membersProject = null;
-					if(((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_GUEST_MEMBERS)){
+				// Implemented the use of the "/memberships" route to optimize the query of the
+				// accesses of each user
+
+				String REGEX = "[\\[\\]]";
+				String uid = (((ContainsAllValuesFilter) query).getAttribute().getValue()).toString();
+
+				uid = uid.replaceAll(REGEX, "");
+
+				StringBuilder sbPath = new StringBuilder();
+				sbPath.append(USERS).append("/").append(uid).append("/").append(USERS_MEMBERSHIPS_URL);
+				String TYPE_MEMBERSHIPS_GROUP = "Project";
+				Map<Integer, Integer> projectByAccess = new HashMap<Integer, Integer>();
+
+				JSONArray projectWithMPMembers = new JSONArray();
+
+				Integer countOfSameMember = 0;
+
+				UserProcessing userProcessing = new UserProcessing(configuration, httpclient);
+				projectByAccess = userProcessing.getUserAccess(sbPath.toString(), TYPE_MEMBERSHIPS_GROUP);
+
+				Iterator<Integer> it = projectByAccess.keySet().iterator();
+
+				JSONObject project = new JSONObject();
+
+				while (it.hasNext()) {
+					Object projectID = it.next();
+
+					StringBuilder sbProjectPath = new StringBuilder();
+					sbProjectPath.append(PROJECTS).append("/").append(projectID);
+
+					URIBuilder uribuilderMember = createRequestForMembers(sbProjectPath.toString());
+					Map<Integer, List<String>> mapMembersProjects = getMembers(uribuilderMember);
+
+					List<String> membersProject = null;
+					if (((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_GUEST_MEMBERS)) {
 						membersProject = mapMembersProjects.get(10);
 					}
-					if(((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_REPORTER_MEMBERS)){
+					if (((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_REPORTER_MEMBERS)) {
 						membersProject = mapMembersProjects.get(20);
 					}
-					if(((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_DEVELOPER_MEMBERS)){
+					if (((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_DEVELOPER_MEMBERS)) {
 						membersProject = mapMembersProjects.get(30);
 					}
-					if(((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_MASTER_MEMBERS)){
+					if (((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_MASTER_MEMBERS)) {
 						membersProject = mapMembersProjects.get(40);
 					}
-					if(membersProject != null){
-						for(Object MPProjectMember : allValues){
-						
-							for(String projectMember : membersProject){
-								if(projectMember.equals((String)MPProjectMember)){
+					if (membersProject != null) {
+						for (Object MPProjectMember : allValues) {
+
+							for (String projectMember : membersProject) {
+								if (projectMember.equals((String) MPProjectMember)) {
 									countOfSameMember++;
 									break;
 								}
 							}
 						}
-						if(countOfSameMember == allValues.size()){
-							projectsWithMPMembers.put(project);
+						if (countOfSameMember == allValues.size()) {
+							project = findProjectByID(projectID.toString(), options);
+							projectWithMPMembers.put(project);
 						}
 					}
-					
 				}
-				
-				processingObjectFromGET(projectsWithMPMembers, handler);
-			} else if (((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_SHARED_WITH_GROUPS_ID_MAX_GUEST) ||
-					((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_SHARED_WITH_GROUPS_ID_MAX_REPORTER)||
-					((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_SHARED_WITH_GROUPS_ID_MAX_DEVELOPER)||
-					((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_SHARED_WITH_GROUPS_ID_MAX_MASTER)) {
+				LOGGER.info("projectWithMPMembers -  members: {0}", projectWithMPMembers);
+				processingObjectFromGET(projectWithMPMembers, handler);
+
+			} else if (((ContainsAllValuesFilter) query).getAttribute().getName()
+					.equals(ATTR_SHARED_WITH_GROUPS_ID_MAX_GUEST)
+					|| ((ContainsAllValuesFilter) query).getAttribute().getName()
+							.equals(ATTR_SHARED_WITH_GROUPS_ID_MAX_REPORTER)
+					|| ((ContainsAllValuesFilter) query).getAttribute().getName()
+							.equals(ATTR_SHARED_WITH_GROUPS_ID_MAX_DEVELOPER)
+					|| ((ContainsAllValuesFilter) query).getAttribute().getName()
+							.equals(ATTR_SHARED_WITH_GROUPS_ID_MAX_MASTER)) {
 
 				List<Object> allValues = ((ContainsAllValuesFilter) query).getAttribute().getValue();
 				if (allValues == null) {
@@ -645,61 +687,60 @@ public class ProjectProcessing extends GroupOrProjectProcessing {
 					LOGGER.error(sb.toString());
 					throw new InvalidAttributeValueException(sb.toString());
 				}
-				
-				for(Object value:allValues){
-					if(value == null){
+
+				for (Object value : allValues) {
+					if (value == null) {
 						invalidAttributeValue(((ContainsAllValuesFilter) query).getAttribute().getName(), query);
 					}
 				}
-				
+
 				JSONArray projects = new JSONArray();
 				JSONArray partOfProjects = new JSONArray();
 				int iii = 1;
-				do{
+				do {
 					Map<String, String> parameters = new HashMap<String, String>();
 					parameters.put(PAGE, String.valueOf(iii));
 					parameters.put(PER_PAGE, "100");
-					
+
 					partOfProjects = (JSONArray) executeGetRequest(PROJECTS, parameters, null, true);
 					Iterator<Object> iterator = partOfProjects.iterator();
-					while(iterator.hasNext()){
+					while (iterator.hasNext()) {
 						Object project = iterator.next();
 						projects.put(project);
 					}
 					iii++;
-				} while(partOfProjects.length() == 100);
-				
-				
+				} while (partOfProjects.length() == 100);
+
 				JSONArray projectsSharedWithMPGroups = new JSONArray();
 				JSONObject project;
 				for (int i = 0; i < projects.length(); i++) {
 					project = projects.getJSONObject(i);
 					Integer countOfSameGroups = 0;
-				
+
 					if (project.has(ATTR_SHARED_WITH_GROUPS)) {
 						Object valueObject = project.get(ATTR_SHARED_WITH_GROUPS);
-						if (valueObject != null && !JSONObject.NULL.equals(valueObject) && valueObject instanceof JSONArray) {
+						if (valueObject != null && !JSONObject.NULL.equals(valueObject)
+								&& valueObject instanceof JSONArray) {
 							JSONArray objectArray = (JSONArray) valueObject;
 							for (int ii = 0; ii < objectArray.length(); ii++) {
 								if (objectArray.get(ii) instanceof JSONObject) {
 									JSONObject jsonObject = objectArray.getJSONObject(ii);
 									String groupId = String.valueOf(jsonObject.get(ATTR_GROUP_ID));
-									for(Object MPSharedWithGroup : allValues){
-										
-										if(groupId.equals((String)MPSharedWithGroup)){
+									for (Object MPSharedWithGroup : allValues) {
+
+										if (groupId.equals((String) MPSharedWithGroup)) {
 											countOfSameGroups++;
 											break;
 										}
 									}
-									if(countOfSameGroups == allValues.size()){
+									if (countOfSameGroups == allValues.size()) {
 										projectsSharedWithMPGroups.put(project);
 									}
 								}
 							}
-						} 
+						}
 					}
 				}
-				
 				processingObjectFromGET(projectsSharedWithMPGroups, handler);
 			} else {
 				StringBuilder sb = new StringBuilder();
@@ -717,17 +758,29 @@ public class ProjectProcessing extends GroupOrProjectProcessing {
 			LOGGER.error(sb.toString());
 			throw new ConnectorIOException(sb.toString());
 		}
-
 	}
-	
+
+	private JSONObject findProjectByID(String projectID, OperationOptions options) {
+		Map<String, String> parameters = new HashMap<>();
+		parameters.put("with_custom_attributes", "no");
+		StringBuilder sbPath = new StringBuilder();
+
+		sbPath.append(PROJECTS).append("/").append(projectID);
+		JSONObject project = (JSONObject) executeGetRequest(sbPath.toString(), parameters, options, false);
+		if (project.getInt(UID) == Integer.parseInt(projectID)) {
+			return project;
+		}
+		return null;
+	}
+
 	private void addAttributeForSharedProjects(JSONObject object, ConnectorObjectBuilder builder) {
-		
+
 		List<String> guestSharedWithGroup = new ArrayList<>();
 		List<String> reporterSharedWithGroup = new ArrayList<>();
 		List<String> developerSharedWithGroup = new ArrayList<>();
 		List<String> masterSharedWithGroup = new ArrayList<>();
 		List<String> sharedWithGroupWithName = new ArrayList<>();
-		
+
 		if (object.has(ATTR_SHARED_WITH_GROUPS)) {
 			Object valueObject = object.get(ATTR_SHARED_WITH_GROUPS);
 			if (valueObject != null && !JSONObject.NULL.equals(valueObject)) {
@@ -738,42 +791,44 @@ public class ProjectProcessing extends GroupOrProjectProcessing {
 							JSONObject jsonObject = objectArray.getJSONObject(i);
 							String groupId = String.valueOf(jsonObject.get(ATTR_GROUP_ID));
 							String groupName = String.valueOf(jsonObject.get(ATTR_GROUP_NAME));
-							int access_level = (int)jsonObject.get(ATTR_GROUP_ACCESS_LEVEL);
-							
-							if(access_level == 10){
+							int access_level = (int) jsonObject.get(ATTR_GROUP_ACCESS_LEVEL);
+
+							if (access_level == 10) {
 								guestSharedWithGroup.add(groupId);
 							}
-							if(access_level == 20){
+							if (access_level == 20) {
 								reporterSharedWithGroup.add(groupId);
 							}
-							if(access_level == 30){
+							if (access_level == 30) {
 								developerSharedWithGroup.add(groupId);
 							}
-							if(access_level == 40){
+							if (access_level == 40) {
 								masterSharedWithGroup.add(groupId);
 							}
 							StringBuilder sb = new StringBuilder();
 							sb.append(groupName).append(":").append(access_level);
 							sharedWithGroupWithName.add(sb.toString());
-						} 
+						}
 					}
-					
-					if(!guestSharedWithGroup.isEmpty()){
+
+					if (!guestSharedWithGroup.isEmpty()) {
 						builder.addAttribute(ATTR_SHARED_WITH_GROUPS_ID_MAX_GUEST, guestSharedWithGroup.toArray());
 					}
-					if(!reporterSharedWithGroup.isEmpty()){
-						builder.addAttribute(ATTR_SHARED_WITH_GROUPS_ID_MAX_REPORTER, reporterSharedWithGroup.toArray());
+					if (!reporterSharedWithGroup.isEmpty()) {
+						builder.addAttribute(ATTR_SHARED_WITH_GROUPS_ID_MAX_REPORTER,
+								reporterSharedWithGroup.toArray());
 					}
-					if(!developerSharedWithGroup.isEmpty()){
-						builder.addAttribute(ATTR_SHARED_WITH_GROUPS_ID_MAX_DEVELOPER, developerSharedWithGroup.toArray());
+					if (!developerSharedWithGroup.isEmpty()) {
+						builder.addAttribute(ATTR_SHARED_WITH_GROUPS_ID_MAX_DEVELOPER,
+								developerSharedWithGroup.toArray());
 					}
-					if(!masterSharedWithGroup.isEmpty()){
+					if (!masterSharedWithGroup.isEmpty()) {
 						builder.addAttribute(ATTR_SHARED_WITH_GROUPS_ID_MAX_MASTER, masterSharedWithGroup.toArray());
 					}
-					if(!sharedWithGroupWithName.isEmpty()){
+					if (!sharedWithGroupWithName.isEmpty()) {
 						builder.addAttribute(ATTR_SHARED_WITH_GROUPS_WITH_NAME, sharedWithGroupWithName.toArray());
 					}
-				} 
+				}
 			}
 		}
 	}
@@ -787,7 +842,7 @@ public class ProjectProcessing extends GroupOrProjectProcessing {
 		LOGGER.info("addAtributeMembers, connectorObject: {0}", connectorObject.toString());
 		handler.handle(connectorObject);
 	}
-	
+
 	private void processingObjectFromGET(JSONArray projects, ResultsHandler handler) {
 		JSONObject project;
 		for (int i = 0; i < projects.length(); i++) {
@@ -797,39 +852,38 @@ public class ProjectProcessing extends GroupOrProjectProcessing {
 			processingObjectFromGET(project, handler, sbPath.toString());
 		}
 	}
-	
+
 	public void updateDeltaMultiValues(Uid uid, Set<AttributeDelta> attributesDelta, OperationOptions options) {
 		updateDeltaMultiValuesForGroupOrProject(uid, attributesDelta, options, PROJECTS);
 		for (AttributeDelta attrDelta : attributesDelta) {
 
-			if (ATTR_SHARED_WITH_GROUPS_ID_MAX_GUEST.equals(attrDelta.getName())) {  
+			if (ATTR_SHARED_WITH_GROUPS_ID_MAX_GUEST.equals(attrDelta.getName())) {
 				createOrDeleteSharingWithGroup(uid, attrDelta, 10);
 			}
-			if (ATTR_SHARED_WITH_GROUPS_ID_MAX_REPORTER.equals(attrDelta.getName())) {  
+			if (ATTR_SHARED_WITH_GROUPS_ID_MAX_REPORTER.equals(attrDelta.getName())) {
 				createOrDeleteSharingWithGroup(uid, attrDelta, 20);
 			}
-			if (ATTR_SHARED_WITH_GROUPS_ID_MAX_DEVELOPER.equals(attrDelta.getName())) {  
+			if (ATTR_SHARED_WITH_GROUPS_ID_MAX_DEVELOPER.equals(attrDelta.getName())) {
 				createOrDeleteSharingWithGroup(uid, attrDelta, 30);
 			}
-			if (ATTR_SHARED_WITH_GROUPS_ID_MAX_MASTER.equals(attrDelta.getName())) {  
+			if (ATTR_SHARED_WITH_GROUPS_ID_MAX_MASTER.equals(attrDelta.getName())) {
 				createOrDeleteSharingWithGroup(uid, attrDelta, 40);
 			}
-			if (ATTR_TAG_LIST.equals(attrDelta.getName())) {  
+			if (ATTR_TAG_LIST.equals(attrDelta.getName())) {
 				createOrDeleteTagList(uid, attrDelta);
 			}
 		}
 	}
-	
-	private void createOrDeleteTagList(Uid uid, AttributeDelta attrDelta){
+
+	private void createOrDeleteTagList(Uid uid, AttributeDelta attrDelta) {
 		StringBuilder sbPath = new StringBuilder();
 		sbPath.append(PROJECTS).append("/").append(uid.getUidValue());
-			
-		JSONObject project = (JSONObject) executeGetRequest(sbPath.toString(), null,
-				null, false);
-		
+
+		JSONObject project = (JSONObject) executeGetRequest(sbPath.toString(), null, null, false);
+
 		JSONArray jsonArrayTagList = (JSONArray) project.get(ATTR_TAG_LIST);
-		List<Object> tagList = jsonArrayTagList.toList(); 
-		
+		List<Object> tagList = jsonArrayTagList.toList();
+
 		List<Object> addValues = attrDelta.getValuesToAdd();
 		List<Object> removeValues = attrDelta.getValuesToRemove();
 		if (addValues != null && !addValues.isEmpty()) {
@@ -837,7 +891,7 @@ public class ProjectProcessing extends GroupOrProjectProcessing {
 			for (Object addValue : addValues) {
 				if (addValue != null && !tagList.contains(addValue)) {
 					tagList.add(addValue);
-					
+
 				}
 			}
 		}
@@ -845,7 +899,7 @@ public class ProjectProcessing extends GroupOrProjectProcessing {
 			for (Object removeValue : removeValues) {
 				if (removeValue != null && tagList.contains(removeValue)) {
 					tagList.remove(removeValue);
-					
+
 				}
 			}
 		}
@@ -856,11 +910,11 @@ public class ProjectProcessing extends GroupOrProjectProcessing {
 		LOGGER.info("json: {0}", json.toString());
 		createPutOrPostRequest(uid, PROJECTS, json, create);
 	}
-	
-	private void createOrDeleteSharingWithGroup(Uid uid, AttributeDelta attrDelta, int accessLevel){
+
+	private void createOrDeleteSharingWithGroup(Uid uid, AttributeDelta attrDelta, int accessLevel) {
 		StringBuilder sbPath = new StringBuilder();
 		sbPath.append(PROJECTS).append("/").append(uid.getUidValue()).append(SHARE);
-			
+
 		List<Object> addValues = attrDelta.getValuesToAdd();
 		List<Object> removeValues = attrDelta.getValuesToRemove();
 		if (addValues != null && !addValues.isEmpty()) {

--- a/src/test/java/com/evolveum/polygon/connector/gitlab/rest/TesteVH.java
+++ b/src/test/java/com/evolveum/polygon/connector/gitlab/rest/TesteVH.java
@@ -1,0 +1,25 @@
+package com.evolveum.polygon.connector.gitlab.rest;
+
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public class TesteVH {
+  public static void main(String[] args) {
+  
+   // Initialize Variables
+   JSONArray groupsWithMPMembers = new JSONArray();
+   JSONObject group= new JSONObject();
+   
+
+   // Put data
+   group.put("id","500");
+   group.put("name", "teste");
+   
+   System.out.println(group);
+   
+   groupsWithMPMembers.put(group);
+    // Print the first item
+    System.out.println(groupsWithMPMembers);
+  }
+}


### PR DESCRIPTION
As of GitLab version 12.8[1], there was a route in the "/users/:id/memberships" namespace that allows you to query which project or project the user is a part of. I made this implementation, based on the ObjectClass type of the "executeQuery" request, that would improve the permissions that were mapped to the user. There are changes in all files, however, today they change their code formatting for the files "UserProcessing.java", "GroupProcessing.java" and "ProjectProcessing.java"

NOTE: The environment in which I am using the connector has 609 Projects, 661 Groups and 207 Users.

[1] https://docs.gitlab.com/ee/api/users.html#user-memberships-admin-only