### PR TITLE
Implementation of performance improvements /Groups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 	</parent>
 
 	<artifactId>connector-gitlab-rest</artifactId>
-	<version>1.2.3-SNAPSHOT</version>
+	<version>1.2.5-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>REST Connector Gitlab</name>
@@ -113,6 +113,12 @@
     		<groupId>org.apache.commons</groupId>
     		<artifactId>commons-lang3</artifactId>
     		<version>3.0</version>
+		</dependency>
+		
+		<dependency>
+    		<groupId>com.googlecode.json-simple</groupId>
+    		<artifactId>json-simple</artifactId>
+    		<version>1.1.1</version>
 		</dependency>
 
 	</dependencies>

--- a/src/main/java/com/evolveum/polygon/connector/gitlab/rest/GroupProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/gitlab/rest/GroupProcessing.java
@@ -59,6 +59,7 @@ public class GroupProcessing extends GroupOrProjectProcessing {
 	private static final String ATTR_FULL_NAME = "full_name";
 	private static final String ATTR_FULL_PATH = "full_path";
 
+	
 	public GroupProcessing(GitlabRestConfiguration configuration, CloseableHttpClient httpclient) {
 		super(configuration, httpclient);
 	}
@@ -251,7 +252,7 @@ public class GroupProcessing extends GroupOrProjectProcessing {
 		getIfExists(group, ATTR_PARENT_ID, Integer.class, builder);
 		getIfExists(group, ATTR_FULL_NAME, String.class, builder);
 		getIfExists(group, ATTR_FULL_PATH, String.class, builder);
-
+		
 		getMultiIfExists(group, ATTR_PROJECTS, builder);
 		getMultiIfExists(group, ATTR_SHARED_PROJECTS, builder);
 
@@ -339,7 +340,6 @@ public class GroupProcessing extends GroupOrProjectProcessing {
 				String TYPE_MEMBERSHIPS_GROUP = "Namespace";
 				Map<Integer, Integer> groupByAccess = new HashMap<Integer, Integer>();
 				JSONArray groupsWithMPMembers = new JSONArray();
-				Integer countOfSameMember = 0;
 
 				UserProcessing userProcessing = new UserProcessing(configuration, httpclient);
 				groupByAccess = userProcessing.getUserAccess(sbPath.toString(), TYPE_MEMBERSHIPS_GROUP);
@@ -353,10 +353,10 @@ public class GroupProcessing extends GroupOrProjectProcessing {
 
 					StringBuilder sbGroupPath = new StringBuilder();
 					sbGroupPath.append(GROUPS).append("/").append(groupID);
-
+					
 					URIBuilder uribuilderMember = createRequestForMembers(sbGroupPath.toString());
 					Map<Integer, List<String>> mapMembersGroup = getMembers(uribuilderMember);
-
+                    // Attribute: {Name=owner_members, Value=[57]}
 					List<String> membersGroup = null;
 					if (((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_GUEST_MEMBERS)) {
 						membersGroup = mapMembersGroup.get(10);
@@ -377,14 +377,11 @@ public class GroupProcessing extends GroupOrProjectProcessing {
 						for (Object MPGroupMember : allValues) {
 							for (String groupMember : membersGroup) {
 								if (groupMember.equals((String) MPGroupMember)) {
-									countOfSameMember++;
+									group = findGroupByID(groupID.toString(), options);
+									groupsWithMPMembers.put(group);
 									break;
 								}
 							}
-						}
-						if (countOfSameMember == allValues.size()) {
-							group = findGroupByID(groupID.toString(), options);
-							groupsWithMPMembers.put(group);
 						}
 					}
 				}

--- a/src/main/java/com/evolveum/polygon/connector/gitlab/rest/ObjectProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/gitlab/rest/ObjectProcessing.java
@@ -205,6 +205,7 @@ public class ObjectProcessing {
 		LOGGER.info("response: {0}", response);
 
 		processResponseErrors(response);
+		
 
 		if (!parseResult) {
 			return null;
@@ -325,6 +326,7 @@ public class ObjectProcessing {
 		// create URI for request
 		if (create) {
 			uriBuilder.setPath(path);
+			LOGGER.info("CREATE POST REQUEST FOR: {0} ", uriBuilder);
 		} else {
 			StringBuilder sbPath = new StringBuilder();
 			sbPath.append(path).append("/").append(uid.getUidValue());
@@ -474,6 +476,30 @@ public class ObjectProcessing {
 			throw new ConnectorException(sb.toString(), e);
 		}
 	}
+	
+	protected int getTotalPagesByPath(String path) {
+		LOGGER.info("getTotalPagesByPath path {0}", path);
+		URIBuilder uribuilder = getURIBuilder();
+		uribuilder.clearParameters();
+		int totalPagesByPath;
+		uribuilder.setPath(path);
+		uribuilder.setParameter(PER_PAGE, "100");
+
+		try {
+			URI uri = uribuilder.build();
+			// Get X-Total-Pages
+			HttpRequestBase totalPagesrequest = new HttpGet(uri);
+			totalPagesByPath = getTotalPages(totalPagesrequest);
+
+			return totalPagesByPath;
+
+		} catch (URISyntaxException e) {
+			StringBuilder sb = new StringBuilder();
+			sb.append("It was not possible create URI from UriBuider:").append(uriBuilder).append(";")
+					.append(e.getLocalizedMessage());
+			throw new ConnectorException(sb.toString(), e);
+		}
+	}
 
 	protected Object executeGetRequest(String path, Map<String, String> parameters, OperationOptions options,
 			Boolean resultIsArray) {
@@ -516,7 +542,7 @@ public class ObjectProcessing {
 					if (options == null || options.getPageSize() == null) {
 						uribuilder.addParameter(PER_PAGE, "100");
 					}
-					for (int i = 0; i < totalPages; i++) {
+					for (int i = 1; i <= totalPages; i++) {
 						URI uriPaged = uribuilder.setParameter(PAGE, Integer.toString(i)).build();
 						HttpRequestBase requestPaged = new HttpGet(uriPaged);
 						JSONArray responcePaged = callRequestForJSONArray(requestPaged, true);

--- a/src/main/java/com/evolveum/polygon/connector/gitlab/rest/ProjectProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/gitlab/rest/ProjectProcessing.java
@@ -103,7 +103,8 @@ public class ProjectProcessing extends GroupOrProjectProcessing {
 	private static final String ATTR_SHARED_WITH_GROUPS_WITH_NAME = "shared_with_groups.name-access_level";
 
 	private static final String ATTR_GROUP_ID = "group_id";
-	private static final String ATTR_GROUP_NAME = "group_name";
+	//private static final String ATTR_GROUP_NAME = "group_name";
+	private static final String ATTR_GROUP_FULL_PATH = "group_full_path";
 	private static final String ATTR_GROUP_ACCESS_LEVEL = "group_access_level";
 	private static final String ATTR_GROUP_ACCESS = "group_access";
 
@@ -697,7 +698,7 @@ public class ProjectProcessing extends GroupOrProjectProcessing {
 				JSONArray projects = new JSONArray();
 				JSONArray partOfProjects = new JSONArray();
 				int iii = 1;
-				do {
+
 					Map<String, String> parameters = new HashMap<String, String>();
 					parameters.put(PAGE, String.valueOf(iii));
 					parameters.put(PER_PAGE, "100");
@@ -708,8 +709,9 @@ public class ProjectProcessing extends GroupOrProjectProcessing {
 						Object project = iterator.next();
 						projects.put(project);
 					}
-					iii++;
-				} while (partOfProjects.length() == 100);
+					LOGGER.info("Value of PAGE : {0}", iii);
+					LOGGER.info("Value of ParfOfProjects Lenght : {0}", partOfProjects.length());
+					LOGGER.info("Value of Projects Lenght : {0}", projects.length());
 
 				JSONArray projectsSharedWithMPGroups = new JSONArray();
 				JSONObject project;
@@ -790,7 +792,8 @@ public class ProjectProcessing extends GroupOrProjectProcessing {
 						if (objectArray.get(i) instanceof JSONObject) {
 							JSONObject jsonObject = objectArray.getJSONObject(i);
 							String groupId = String.valueOf(jsonObject.get(ATTR_GROUP_ID));
-							String groupName = String.valueOf(jsonObject.get(ATTR_GROUP_NAME));
+							//String groupName = String.valueOf(jsonObject.get(ATTR_GROUP_NAME));
+							String groupFullPath = String.valueOf(jsonObject.get(ATTR_GROUP_FULL_PATH));
 							int access_level = (int) jsonObject.get(ATTR_GROUP_ACCESS_LEVEL);
 
 							if (access_level == 10) {
@@ -806,7 +809,7 @@ public class ProjectProcessing extends GroupOrProjectProcessing {
 								masterSharedWithGroup.add(groupId);
 							}
 							StringBuilder sb = new StringBuilder();
-							sb.append(groupName).append(":").append(access_level);
+							sb.append(groupFullPath).append(":").append(access_level);
 							sharedWithGroupWithName.add(sb.toString());
 						}
 					}

--- a/src/main/java/com/evolveum/polygon/connector/gitlab/rest/UserProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/gitlab/rest/UserProcessing.java
@@ -811,6 +811,43 @@ public class UserProcessing extends ObjectProcessing {
 		LOGGER.info("getUserAccess End");
 		return output;
 	}
+	
+	// A ideia dessa função é ter um atalho para mapear os acessos dos usuários de forma que possamos utiliza-la como atalho nas buscas
+	// e além da velocidade resolver o problema de associação.
+	public Map<Integer, Integer> getMemberOf(String sbPath, String type) {
+		LOGGER.info("getUserAccess Start");
+		// Get groups or project to manage is informed by user on connector configuration
+		Map<String, String> groupsToManage = getGroupsForFilter(this.configuration.getGroupsToManage());
+		Map<Integer, Integer> output = new HashMap<Integer, Integer>();
+		JSONArray groupsOrProjects = new JSONArray();
+		JSONArray partOfGroupsOrProjects = new JSONArray();
+		Map<String, String> parameters = new HashMap<String, String>();
+
+		parameters.put(PER_PAGE, "100");
+		parameters.put(TYPE_MEMBERSHIPS, type);
+
+		// Get all groups or projects for user
+		partOfGroupsOrProjects = (JSONArray) executeGetRequest(sbPath, parameters, null, true);
+		Iterator<Object> iterator = partOfGroupsOrProjects.iterator();
+		while (iterator.hasNext()) {
+			Object groupOrProject = iterator.next();
+			if (groupsToManage == null) {
+				groupsOrProjects.put(groupOrProject);
+			} else if (groupsToManage
+					.containsKey(new JSONObject(groupOrProject.toString()).getString("name").toLowerCase())) {
+				groupsOrProjects.put(groupOrProject);
+			}
+		}
+		for (int i = 0; i < groupsOrProjects.length(); i++) {
+			JSONObject jsonGroupOrProject = groupsOrProjects.getJSONObject(i);
+			int sourceID = (int) (jsonGroupOrProject.get(ATTR_USER_MEMBERSHIPS_SRC_ID));
+			int accessLevel = (int) jsonGroupOrProject.get(ATTR_USER_MEMBERSHIPS_ACCESS_LEVEL);
+
+			output.put(sourceID, accessLevel);
+		}
+		LOGGER.info("getUserAccess End");
+		return output;
+	}
 
 	private Map<String, String> getGroupsForFilter(String groupsToManage) {
 		LOGGER.info("getGroupsForFilter Start");

--- a/src/test/java/com/evolveum/polygon/connector/gitlab/rest/TesteVH.java
+++ b/src/test/java/com/evolveum/polygon/connector/gitlab/rest/TesteVH.java
@@ -1,25 +1,64 @@
 package com.evolveum.polygon.connector.gitlab.rest;
 
 
-import org.json.JSONArray;
-import org.json.JSONObject;
-
 public class TesteVH {
-  public static void main(String[] args) {
-  
-   // Initialize Variables
-   JSONArray groupsWithMPMembers = new JSONArray();
-   JSONObject group= new JSONObject();
-   
+	//public static void main(String[] args) throws IOException, ParseException {
 
-   // Put data
-   group.put("id","500");
-   group.put("name", "teste");
-   
-   System.out.println(group);
-   
-   groupsWithMPMembers.put(group);
-    // Print the first item
-    System.out.println(groupsWithMPMembers);
-  }
+//		//String groupName = "group-prod-n1-conta-digital-android";
+//		String[] groupStr = name.split("-");
+//
+//		int arrayLength = groupStr.length;
+//
+//		String namespaceFirst = groupStr[2];
+//
+//		switch (namespaceFirst) {
+//		case "n1":
+//			namespaceFirst = "nivel1";
+//			break;
+//		case "n2":
+//			namespaceFirst = "nivel2";
+//			break;
+//		case "n3":
+//			namespaceFirst = "nivel3";
+//			break;
+//		case "dev":
+//			namespaceFirst = "desenvolvimento";
+//			break;
+//		case "infra":
+//			namespaceFirst = "infraestrutura";
+//			break;
+//		default:
+//			break;
+//		}
+//
+//		String namespace = namespaceFirst;
+//
+//		for (int count = 3; count < arrayLength; count++) {
+//			if (count == 3) {
+//				namespace = namespace + '/' + groupStr[count];
+//			} else {
+//				namespace = namespace + '-' + groupStr[count];
+//			}
+//		}
+//
+//		String mdRoleName = "Gerencianet/Role/Single/Production/Nivel1/Gitlab/" + namespace + "/" + name + "/Maintainer";
+//		role = midpoint.searchObjectByName(RoleType.class, mdRoleName);
+//		
+//		if (role==null){
+//            throw new SystemException("Exception while assigning the permision role. Please make sure that all the role (permision role) are already added into Midpoint. GroupName: " + name);
+//        }
+//		
+//		roleOrt = new ObjectReferenceType();
+//        roleOrt.setOid(role.getOid());
+//        roleOrt.setType(RoleType.COMPLEX_TYPE);
+//        
+//        AssignmentType assignment = new AssignmentType();
+//        assignment.asPrismContainerValue()
+//        assignment.setTargetRef(roleOrt);
+//        
+//        delta = midpoint.prismContext.deltaFactory().object().createModificationAddContainer(OrgType.class, org.getOid(), OrgType.F_ASSIGNMENT, assignment);
+//        midpoint.executeChanges(delta)
+
+
+	//}
 }


### PR DESCRIPTION
- Fixed issue when gitlab had more than 100 groups. The connector couldn't enumerate all the groups when it would check which the user was a part of;
- Improved search for groups/projects that the user is part of, reducing search time.