### PR TITLE
Update ConnID Framework, Bugfixes and GH Actions Pipeline

### DIFF
--- a/.github/workflows/publish-releases.yml
+++ b/.github/workflows/publish-releases.yml
@@ -1,0 +1,28 @@
+name: Publish package to GitHub Packages
+on:
+  push:
+    tags:
+      - "v*.*.*"
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+          cache: 'maven'
+      - name: Update version in pom.xml
+        run: mvn -B versions:set -DnewVersion=${{ github.ref_name }} -DgenerateBackupPoms=false
+      - name: mvn package
+        run: mvn --batch-mode package -Dmaven.test.skip=true
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: target/*.jar
+          prerelease: true
+          fail_on_unmatched_files: true

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 	</parent>
 
 	<artifactId>connector-gitlab-rest</artifactId>
-	<version>1.2.3-SNAPSHOT</version>
+	<version>2.0.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>REST Connector Gitlab</name>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<artifactId>connector-parent</artifactId>
 		<groupId>com.evolveum.polygon</groupId>
-		<version>1.4.2.18</version>
+		<version>1.5.1.3</version>
 		<relativePath></relativePath>
 	</parent>
 
@@ -33,17 +33,17 @@
 		<repository>
 			<id>evolveum-nexus-releases</id>
 			<name>Internal Releases</name>
-			<url>http://nexus.evolveum.com/nexus/content/repositories/releases/</url>
+			<url>https://nexus.evolveum.com/nexus/content/repositories/releases/</url>
 		</repository>
 		<repository>
 			<id>evolveum-nexus-snapshots</id>
 			<name>Internal Releases</name>
-			<url>http://nexus.evolveum.com/nexus/content/repositories/snapshots/</url>
+			<url>https://nexus.evolveum.com/nexus/content/repositories/snapshots/</url>
 		</repository>
 		<repository>
 			<id>apache-snapshots</id>
 			<name>Apache Snapshots</name>
-			<url>http://repository.apache.org/snapshots/</url>
+			<url>https://repository.apache.org/snapshots/</url>
 		</repository>
 	</repositories>
 
@@ -77,7 +77,7 @@
 		<dependency>
 			<artifactId>connector-rest</artifactId>
 			<groupId>com.evolveum.polygon</groupId>
-			<version>1.4.2.18</version>
+			<version>1.5.1.3</version>
 		</dependency>
 <!--		<dependency>
 			<groupId>net.tirasa.connid</groupId>
@@ -88,7 +88,7 @@
 <dependency>
     <groupId>net.tirasa.connid</groupId>
     <artifactId>connector-framework</artifactId>
-    <version>1.4.3.0</version>
+    <version>1.5.1.10</version>
 </dependency>
 
 		<dependency>

--- a/src/main/java/com/evolveum/polygon/connector/gitlab/rest/GroupProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/gitlab/rest/GroupProcessing.java
@@ -339,7 +339,6 @@ public class GroupProcessing extends GroupOrProjectProcessing {
 				String TYPE_MEMBERSHIPS_GROUP = "Namespace";
 				Map<Integer, Integer> groupByAccess = new HashMap<Integer, Integer>();
 				JSONArray groupsWithMPMembers = new JSONArray();
-				Integer countOfSameMember = 0;
 
 				UserProcessing userProcessing = new UserProcessing(configuration, httpclient);
 				groupByAccess = userProcessing.getUserAccess(sbPath.toString(), TYPE_MEMBERSHIPS_GROUP);
@@ -349,6 +348,7 @@ public class GroupProcessing extends GroupOrProjectProcessing {
 				JSONObject group = new JSONObject();
 
 				while (it.hasNext()) {
+					Integer countOfSameMember = 0;
 					Object groupID = it.next();
 
 					StringBuilder sbGroupPath = new StringBuilder();

--- a/src/main/java/com/evolveum/polygon/connector/gitlab/rest/GroupProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/gitlab/rest/GroupProcessing.java
@@ -21,6 +21,7 @@ package com.evolveum.polygon.connector.gitlab.rest;
  */
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -188,7 +189,7 @@ public class GroupProcessing extends GroupOrProjectProcessing {
 		LOGGER.info("Start createOrUpdateGroup, Uid: {0}, attributes: {1}", uid, attributes);
 
 		// create or update
-		Boolean create = (uid == null) ? true : false;
+		boolean create = uid == null;
 
 		JSONObject json = new JSONObject();
 
@@ -318,9 +319,6 @@ public class GroupProcessing extends GroupOrProjectProcessing {
 					|| ((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_OWNER_MEMBERS)) {
 
 				List<Object> allValues = ((ContainsAllValuesFilter) query).getAttribute().getValue();
-				if (allValues == null) {
-
-				}
 
 				for (Object value : allValues) {
 					if (value == null) {
@@ -328,71 +326,54 @@ public class GroupProcessing extends GroupOrProjectProcessing {
 					}
 				}
 
-				String REGEX = "[\\[\\]]";
-				String uid = (((ContainsAllValuesFilter) query).getAttribute().getValue()).toString();
+				String uid = String.valueOf(allValues.get(0));
 
-				uid = uid.replaceAll(REGEX, "");
-
-				StringBuilder sbPath = new StringBuilder();
-				sbPath.append(USERS).append("/").append(uid).append("/").append(USERS_MEMBERSHIPS_URL);
-
-				String TYPE_MEMBERSHIPS_GROUP = "Namespace";
-				Map<Integer, Integer> groupByAccess = new HashMap<Integer, Integer>();
 				JSONArray groupsWithMPMembers = new JSONArray();
 
 				UserProcessing userProcessing = new UserProcessing(configuration, httpclient);
-				groupByAccess = userProcessing.getUserAccess(sbPath.toString(), TYPE_MEMBERSHIPS_GROUP);
+				Map<Integer, Integer> groupByAccess = userProcessing.getUserAccess(USERS + "/" + uid + "/" + USERS_MEMBERSHIPS_URL, UserProcessing.TYPE_MEMBERSHIPS_GROUP);
 
-				Iterator<Integer> it = groupByAccess.keySet().iterator();
-
-				JSONObject group = new JSONObject();
-
-				while (it.hasNext()) {
-					Integer countOfSameMember = 0;
-					Object groupID = it.next();
-
-					StringBuilder sbGroupPath = new StringBuilder();
-					sbGroupPath.append(GROUPS).append("/").append(groupID);
-
-					URIBuilder uribuilderMember = createRequestForMembers(sbGroupPath.toString());
+				for (int groupID : groupByAccess.keySet()) {
+					URIBuilder uribuilderMember = createRequestForMembers(GROUPS + "/" + groupID);
 					Map<Integer, List<String>> mapMembersGroup = getMembers(uribuilderMember);
 
-					List<String> membersGroup = null;
-					if (((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_GUEST_MEMBERS)) {
-						membersGroup = mapMembersGroup.get(10);
+
+					final List<String> membersGroup;
+					switch (((ContainsAllValuesFilter) query).getAttribute().getName()) {
+						case ATTR_GUEST_MEMBERS:
+							membersGroup = mapMembersGroup.get(10);
+							break;
+						case ATTR_REPORTER_MEMBERS:
+							membersGroup = mapMembersGroup.get(20);
+							break;
+						case ATTR_DEVELOPER_MEMBERS:
+							membersGroup = mapMembersGroup.get(30);
+							break;
+						case ATTR_MASTER_MEMBERS:
+							membersGroup = mapMembersGroup.get(40);
+							break;
+						case ATTR_OWNER_MEMBERS:
+							membersGroup = mapMembersGroup.get(50);
+							break;
+						default:
+							membersGroup = null;
+							break;
 					}
-					if (((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_REPORTER_MEMBERS)) {
-						membersGroup = mapMembersGroup.get(20);
+
+					if (membersGroup == null) {
+						continue;
 					}
-					if (((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_DEVELOPER_MEMBERS)) {
-						membersGroup = mapMembersGroup.get(30);
-					}
-					if (((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_MASTER_MEMBERS)) {
-						membersGroup = mapMembersGroup.get(40);
-					}
-					if (((ContainsAllValuesFilter) query).getAttribute().getName().equals(ATTR_OWNER_MEMBERS)) {
-						membersGroup = mapMembersGroup.get(50);
-					}
-					if (membersGroup != null) {
-						for (Object MPGroupMember : allValues) {
-							for (String groupMember : membersGroup) {
-								if (groupMember.equals((String) MPGroupMember)) {
-									countOfSameMember++;
-									break;
-								}
-							}
-						}
-						if (countOfSameMember == allValues.size()) {
-							group = findGroupByID(groupID.toString(), options);
-							groupsWithMPMembers.put(group);
-						}
+
+					if (new HashSet<>(membersGroup).containsAll(allValues)) {
+						final JSONObject group = findGroupByID(Integer.toString(groupID), options);
+						groupsWithMPMembers.put(group);
 					}
 				}
 				LOGGER.info("groupsWithMPMembers -  members: {0}", groupsWithMPMembers);
 				processingObjectFromGET(groupsWithMPMembers, handler);
 			} else {
 				StringBuilder sb = new StringBuilder();
-				sb.append("Illegal search with attribute ").append(((ContainsFilter) query).getAttribute().getName())
+				sb.append("Illegal search with attribute ").append(((ContainsAllValuesFilter) query).getAttribute().getName())
 						.append(" for query: ").append(query);
 				LOGGER.error(sb.toString());
 				throw new InvalidAttributeValueException(sb.toString());
@@ -438,8 +419,8 @@ public class GroupProcessing extends GroupOrProjectProcessing {
 	}
 
 	private void processingObjectFromGET(JSONObject group, ResultsHandler handler, String sbPath) {
-		byte[] avaratPhoto = getAvatarPhoto(group, ATTR_AVATAR_URL, ATTR_AVATAR);
-		ConnectorObjectBuilder builder = convertGroupJSONObjectToConnectorObject(group, avaratPhoto);
+		byte[] avatarPhoto = getAvatarPhoto(group, ATTR_AVATAR_URL, ATTR_AVATAR);
+		ConnectorObjectBuilder builder = convertGroupJSONObjectToConnectorObject(group, avatarPhoto);
 		addAttributeForMembers(builder, handler, sbPath);
 		ConnectorObject connectorObject = builder.build();
 		handler.handle(connectorObject);
@@ -449,9 +430,7 @@ public class GroupProcessing extends GroupOrProjectProcessing {
 		JSONObject group;
 		for (int i = 0; i < groups.length(); i++) {
 			group = groups.getJSONObject(i);
-			StringBuilder sbPath = new StringBuilder();
-			sbPath.append(GROUPS).append("/").append(group.get(UID));
-			processingObjectFromGET(group, handler, sbPath.toString());
+			processingObjectFromGET(group, handler, GROUPS + "/" + group.get(UID));
 		}
 	}
 

--- a/src/main/java/com/evolveum/polygon/connector/gitlab/rest/UserProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/gitlab/rest/UserProcessing.java
@@ -190,9 +190,7 @@ public class UserProcessing extends ObjectProcessing {
 		userObjClassBuilder.addAttributeInfo(attrLinkedinBuilder.build());
 
 		AttributeInfoBuilder attrIsAdminBuilder = new AttributeInfoBuilder(ATTR_IS_ADMIN);
-//		attrIsAdminBuilder.setType(Boolean.class).setCreateable(true).setUpdateable(true).setReadable(true);
-		attrIsAdminBuilder.setType(Boolean.class).setCreateable(true).setUpdateable(true).setReadable(false)
-				.setReturnedByDefault(false);
+		attrIsAdminBuilder.setType(Boolean.class).setCreateable(true).setUpdateable(true).setReadable(true);
 		userObjClassBuilder.addAttributeInfo(attrIsAdminBuilder.build());
 
 		// createable: TRUE && updateable: FALSE && readable: FALSE
@@ -532,6 +530,7 @@ public class UserProcessing extends ObjectProcessing {
 		getIfExists(user, ATTR_TWO_FACTOR_ENABLED, Boolean.class, builder);
 		getIfExists(user, ATTR_EXTERNAL, Boolean.class, builder);
 		getIfExists(user, ATTR_AVATAR_URL, String.class, builder);
+		getIfExists(user, ATTR_IS_ADMIN, Boolean.class, builder);
 
 		if (user.has(ATTR_STATE)) {
 			boolean enable = STATUS_ACTIVE.equals(user.get(ATTR_STATE).toString());

--- a/src/main/java/com/evolveum/polygon/connector/gitlab/rest/UserProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/gitlab/rest/UserProcessing.java
@@ -120,6 +120,7 @@ public class UserProcessing extends ObjectProcessing {
 	protected static final String ATTR_USER_MEMBERSHIPS_SRC_ID = "source_id";
 	protected static final String ATTR_USER_MEMBERSHIPS_ACCESS_LEVEL = "access_level";
 	protected static final String ATTR_USER_MEMBERSHIPS_SRC_TYPE = "source_type";
+	protected static final String ATTR_USER_MEMBERSHIPS_SRC_NAME = "source_name";
 
 	protected CloseableHttpClient httpclient;
 	private GitlabRestConfiguration configuration;
@@ -797,7 +798,7 @@ public class UserProcessing extends ObjectProcessing {
 			if (groupsToManage == null) {
 				groupsOrProjects.put(groupOrProject);
 			} else if (groupsToManage
-					.containsKey(new JSONObject(groupOrProject.toString()).getString("name").toLowerCase())) {
+					.containsKey(new JSONObject(groupOrProject.toString()).getString(ATTR_USER_MEMBERSHIPS_SRC_NAME).toLowerCase())) {
 				groupsOrProjects.put(groupOrProject);
 			}
 		}

--- a/src/main/java/com/evolveum/polygon/connector/gitlab/rest/UserProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/gitlab/rest/UserProcessing.java
@@ -331,7 +331,10 @@ public class UserProcessing extends ObjectProcessing {
 		putAttrIfExists(attributes, ATTR_IS_ADMIN, Boolean.class, json, ATTR_ADMIN);
 		putAttrIfExists(attributes, ATTR_CAN_CREATE_GROUP, Boolean.class, json);
 		putAttrIfExists(attributes, ATTR_EXTERNAL, Boolean.class, json);
-		putAttrIfExists(attributes, ATTR_CONFIRM, Boolean.class, json);
+
+		if (create) {
+			putAttrIfExists(attributes, ATTR_CONFIRM, Boolean.class, json);
+		}
 
 		if (!create) {
 			putAttrIfExists(attributes, ATTR_RECONFIRM, Boolean.class, json);


### PR DESCRIPTION
This PR does three things:
1. It Updates the connector Framework from ~1.4.3.0~ to 1.5.1.3
    Reason: Current MidPoint LTS (v4.4.4) uses Version 1.5.1.10 and would not discover the built jar otherwise.
2. It introduces a few bugfixes/minor cleanups into the code
    Reason: We needed some of these to use the connector properly...
3.  It introduces a GitHub Actions build Pipeline, which runs on tags in the format `v*.*.*` for semver releases.
    Reason: Latest Public Build of this is `v1.0` from Oct. 2018. Adding the Pipeline should make it easier to release new builds, as you only need to push a tag, and a new release appears in GH.

Edit:
Tested with:
- GitLab: 15.9
- Evolveum MidPoint: 4.4.4 LTS "Tesla" Update 4